### PR TITLE
Admins can no longer select roles

### DIFF
--- a/app/views/admin/users/_form_fields.html.erb
+++ b/app/views/admin/users/_form_fields.html.erb
@@ -30,7 +30,7 @@
 <% if can? :assign_role, User %>
   <p class="form-group">
     <%= f.label :role %><br />
-    <%= f.select :role, options_for_select(filtered_user_roles.map(&:humanize).zip(User.roles), f.object.role), {}, class: "chosen-select form-control", 'data-module' => 'chosen' %>
+    <%= f.select :role, options_for_select(filtered_user_roles.map(&:humanize).zip(filtered_user_roles), f.object.role), {}, class: "chosen-select form-control", 'data-module' => 'chosen' %>
     <span class="help-block">
       <strong>Admins</strong> can create and edit normal users.<br />
       <strong>Superadmins</strong> can create and edit all user types and edit applications.

--- a/lib/abilities/admin.rb
+++ b/lib/abilities/admin.rb
@@ -9,7 +9,7 @@ module Abilities
       can [:read, :create], BatchInvitation
       can :delegate_all_permissions, ::Doorkeeper::Application
       can [:read, :create, :update, :unlock, :invite!, :suspend, :unsuspend,
-            :perform_admin_tasks, :resend_email_change, :cancel_email_change, :assign_role],
+            :perform_admin_tasks, :resend_email_change, :cancel_email_change],
           User,
           { api_user: false,
             role: Roles::Admin.manageable_roles }

--- a/test/integration/inviting_users_test.rb
+++ b/test/integration/inviting_users_test.rb
@@ -1,5 +1,5 @@
 require 'test_helper'
- 
+
 class InvitingUsersTest < ActionDispatch::IntegrationTest
   include EmailHelpers
 
@@ -57,6 +57,24 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
 
       assert_not_nil User.where(email: "fred_admin@example.com", role: "admin").first
       assert_equal "fred_admin@example.com", last_email.to[0]
+      assert_match 'Please confirm your account', last_email.subject
+    end
+  end
+
+  context "a normal user being invited by an admin" do
+    should "create and notify the user" do
+      admin = create(:admin_user)
+      visit root_path
+      signin(admin)
+
+      visit new_user_invitation_path
+      assert has_no_select?("Role")
+      fill_in "Name", with: "Fred Bloggs"
+      fill_in "Email", with: "normal_fred@example.com"
+      click_button "Create user and send email"
+
+      assert_not_nil User.where(email: "normal_fred@example.com", role: "normal").first
+      assert_equal "normal_fred@example.com", last_email.to[0]
       assert_match 'Please confirm your account', last_email.subject
     end
   end


### PR DESCRIPTION
In its current state, the app backend doesn't allow admins to set the role (because for admins, attr_accessible doesn't include the `role` attribute),
so presenting this option in the frontend leads to confusion. This change hides the role dropdown for admins, for now.

This PR also fixes a bug relating to generation of the "role" dropdown (where there was a mismatch between the label and the actual role). Because admin's can't create non-admins, there isn't currently an end-to-end test that verifies this fix.

/cc @vinayvinay this might clash with your Pundit work...