### PR TITLE
Admin email change flow

### DIFF
--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -18,6 +18,7 @@ class ConfirmationsController < Devise::ConfirmationsController
       else
         self.resource = resource_class.confirm_by_token(params[:confirmation_token])
         if resource.errors.empty?
+          EventLog.record_event(resource, EventLog::EMAIL_CHANGE_CONFIRMED)
           set_flash_message(:notice, :confirmed) if is_navigational_format?
           sign_in(resource_name, resource)
           respond_with_navigational(resource){ redirect_to after_confirmation_path_for(resource_name, resource) }
@@ -38,6 +39,7 @@ class ConfirmationsController < Devise::ConfirmationsController
     if self.resource.valid_password?(params[:user][:password])
       self.resource = resource_class.confirm_by_token(params[:confirmation_token])
       if resource.errors.empty?
+        EventLog.record_event(resource, EventLog::EMAIL_CHANGE_CONFIRMED)
         set_flash_message(:notice, :confirmed) if is_navigational_format?
         sign_in(resource_name, resource)
         respond_with_navigational(resource){ redirect_to after_confirmation_path_for(resource_name, resource) }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,6 +21,7 @@ class UsersController < ApplicationController
       flash[:alert] = "Nothing to update."
       render :edit
     elsif current_user.update_attributes(email: params[:user][:email])
+      EventLog.record_event(current_user, EventLog::EMAIL_CHANGE_INITIATIED, current_user)
       redirect_to root_path, notice: "An email has been sent to #{params[:user][:email]}. Follow the link in the email to update your address."
     else
       flash[:alert] = "Failed to change email."

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -23,6 +23,11 @@ class UserMailer < ActionMailer::Base
     mail(to: @user.email, subject: suspension_notification_subject)
   end
 
+  def email_changed_by_admin_notification(user, email_was, to_address)
+    @user, @email_was = user, email_was
+    mail(to: to_address, subject: 'Your email has been updated')
+  end
+
 private
   def suspension_time
     if @days == 1

--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -11,6 +11,8 @@ class EventLog < ActiveRecord::Base
   UNSUCCESSFUL_LOGIN = "Unsuccessful login"
   SUSPENDED_ACCOUNT_AUTHENTICATED_LOGIN = "Unsuccessful login attempt to a suspended account, with the correct username and password"
   UNSUCCESSFUL_PASSPHRASE_CHANGE = "Unsuccessful passphrase change"
+  EMAIL_CHANGE_INITIATIED = "Email change initiated"
+  EMAIL_CHANGE_CONFIRMED = "Email change confirmed"
 
   # API users
   API_USER_CREATED = "Account created"
@@ -23,7 +25,8 @@ class EventLog < ActiveRecord::Base
                                 MANUAL_ACCOUNT_UNLOCK,
                                 API_USER_CREATED,
                                 ACCESS_TOKEN_GENERATED,
-                                ACCESS_TOKEN_REVOKED]
+                                ACCESS_TOKEN_REVOKED,
+                                EMAIL_CHANGE_INITIATIED]
 
   EVENTS_REQUIRING_APPLICATION_ID = [ACCESS_TOKEN_REGENERATED, ACCESS_TOKEN_GENERATED, ACCESS_TOKEN_REVOKED]
 

--- a/app/views/devise/mailer/email_changed_by_admin_notification.html.erb
+++ b/app/views/devise/mailer/email_changed_by_admin_notification.html.erb
@@ -1,0 +1,12 @@
+<p>Hello <%= @user.name %>,</p>
+
+<p>Someone has changed your <%= link_to 'GOV.UK', 'https://www.gov.uk' %> Signon <%= account_name %> email from <%= @email_was %> to <%= @user.email %>.</p>
+
+<p>You will now need to <%= link_to 'sign in', new_user_session_url(protocol: 'https') %> using your new email <%= @user.email %>.</p>
+
+<p>If your email address shouldn't have changed you should contact a managing GOV.UK editor in your organisation or your parent organisation.</p>
+
+<p>All the best,</p>
+
+<p><%= link_to 'GOV.UK', 'https://www.gov.uk' %> team</p>
+<p>Government Digital Service</p>

--- a/app/views/devise/mailer/email_changed_by_admin_notification.text.erb
+++ b/app/views/devise/mailer/email_changed_by_admin_notification.text.erb
@@ -1,0 +1,12 @@
+Hello <%= @user.name %>,
+
+Someone has changed your GOV.UK Signon <%= account_name %> email from <%= @email_was %> to <%= @user.email %>.
+
+You will now need to sign in using your new email <%= @user.email %>.
+
+If your email address shouldn't have changed you should contact a managing GOV.UK editor in your organisation or your parent organisation.
+
+All the best,
+
+GOV.UK team
+Government Digital Service

--- a/test/functional/admin/users_controller_test.rb
+++ b/test/functional/admin/users_controller_test.rb
@@ -281,6 +281,13 @@ class Admin::UsersControllerTest < ActionController::TestCase
         assert_equal "new@email.com", normal_user.email
       end
 
+      should "log an event" do
+        normal_user = create(:user, email: "old@email.com")
+        put :update, id: normal_user.id, user: { email: "new@email.com" }
+
+        assert_equal 1, EventLog.where(event: EventLog::EMAIL_CHANGE_INITIATIED, uid: normal_user.uid, initiator_id: @user.id).count
+      end
+
       should "send email change notifications to old and new email address" do
         Sidekiq::Testing.inline! do
           normal_user = create(:user, email: "old@email.com")

--- a/test/functional/confirmations_controller_test.rb
+++ b/test/functional/confirmations_controller_test.rb
@@ -60,6 +60,11 @@ class ConfirmationsControllerTest < ActionController::TestCase
         assert_redirected_to "/"
         assert_equal @user.reload.email, "new@email.com"
       end
+
+      should "log an event upon confirmation" do
+        get :show, confirmation_token: @user.confirmation_token
+        assert_equal 1, EventLog.where(event: EventLog::EMAIL_CHANGE_CONFIRMED, uid: @user.uid).count
+      end
     end
 
     context "signed in as somebody else" do
@@ -84,6 +89,13 @@ class ConfirmationsControllerTest < ActionController::TestCase
       assert_redirected_to "/"
       assert @controller.user_signed_in?
       assert_equal @user.reload.email, "new@email.com"
+    end
+
+    should "log an event upon confirmation" do
+      put :update,
+            confirmation_token: @user.confirmation_token,
+            user: { password: "this 1s 4 v3333ry s3cur3 p4ssw0rd.!Z" }
+      assert_equal 1, EventLog.where(event: EventLog::EMAIL_CHANGE_CONFIRMED, uid: @user.uid).count
     end
 
     should "reject with an incorrect token" do

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -83,6 +83,11 @@ class UsersControllerTest < ActionController::TestCase
         assert_equal "Confirm your email change", email.subject
         assert_equal "new@email.com", email.to[0]
       end
+
+      should "log an event" do
+        put :update, user: { email: "new@email.com" }
+        assert_equal 1, EventLog.where(event: EventLog::EMAIL_CHANGE_INITIATIED, uid: @user.uid, initiator_id: @user.id).count
+      end
     end
   end
 

--- a/test/integration/email_change_test.rb
+++ b/test/integration/email_change_test.rb
@@ -10,23 +10,20 @@ class EmailChangeTest < ActionDispatch::IntegrationTest
     end
 
     context "for an active user" do
-      should "trigger a confirmation email to the user" do
-        user = create(:user)
+      should "send a notification email and not confirmation email" do
+        Sidekiq::Testing.inline! do
+          user = create(:user)
 
-        visit new_user_session_path
-        signin(@admin)
-        admin_changes_email_address(user: user, new_email: "new@email.com")
+          visit new_user_session_path
+          signin(@admin)
+          admin_changes_email_address(user: user, new_email: "new@email.com")
 
-        assert_equal "new@email.com", last_email.to[0]
-        assert_equal 'Confirm your email change', last_email.subject
-
-        user.reload
-        confirm_email_change(confirmation_token: user.confirmation_token,
-                             password: "this 1s 4 v3333ry s3cur3 p4ssw0rd.!Z")
-        assert_response_contains("Your account was successfully confirmed. You are now signed in.")
+          assert_equal "new@email.com", last_email.to[0]
+          assert_equal 'Your email has been updated', last_email.subject
+        end
       end
 
-      should "show an error and not trigger a confirmation if the email is blank" do
+      should "show an error and not trigger a notification if the email is blank" do
         user = create(:user)
 
         visit new_user_session_path
@@ -39,20 +36,22 @@ class EmailChangeTest < ActionDispatch::IntegrationTest
     end
 
     context "for a user who hasn't accepted their invite yet" do
-      should "resend a confirmation email" do
-        user = User.invite!(name: "Jim", email: "jim@web.com")
+      should "resend the invitation and skip email change notification" do
+        Sidekiq::Testing.inline! do
+          user = User.invite!(name: "Jim", email: "jim@web.com")
 
-        visit new_user_session_path
-        signin(@admin)
-        admin_changes_email_address(user: user, new_email: "new@email.com")
+          visit new_user_session_path
+          signin(@admin)
+          admin_changes_email_address(user: user, new_email: "new@email.com")
 
-        assert_equal "new@email.com", last_email.to[0]
-        assert_equal 'Please confirm your account', last_email.subject
+          assert_equal "new@email.com", last_email.to[0]
+          assert_equal 'Please confirm your account', last_email.subject
 
-        user.reload
-        accept_invitation(invitation_token: user.invitation_token,
-                          password: "this 1s 4 v3333ry s3cur3 p4ssw0rd.!Z")
-        assert_response_contains("Your passphrase was set successfully. You are now signed in.")
+          user.reload
+          accept_invitation(invitation_token: user.invitation_token,
+                            password: "this 1s 4 v3333ry s3cur3 p4ssw0rd.!Z")
+          assert_response_contains("Your passphrase was set successfully. You are now signed in.")
+        end
       end
     end
 


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/6192

for users who have moved from one organisation to another, and consequently have an updated email in Signon, resetting their password is confusing.

they won't receive password reset instructions on their new email if they've not confirmed it yet. sending reset instructions to their old address works, but on most occasions they would have lost access to the old address by then.

hence, we're skipping re-confirmation when an admin updates a user's email address and instead we send a notification to a user's old and new email address informing them about the update.

also adding events to the users access log when email is changed and the change is accepted.