### PR TITLE
Admin email change flow

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -17,11 +17,17 @@ class Admin::UsersController < ApplicationController
   def update
     authorize! :read, Organisation.find(params[:user][:organisation_id]) if params[:user][:organisation_id].present?
 
-    email_before = @user.email
+    @user.skip_reconfirmation!
     if @user.update_attributes(translate_faux_signin_permission(params[:user]), as: current_user.role.to_sym)
       @user.permissions.reload
       PermissionUpdater.perform_on(@user)
-      @user.invite! if @user.invited_but_not_yet_accepted? && (email_before != @user.email)
+
+      if email_change = @user.previous_changes[:email]
+        @user.invite! if @user.invited_but_not_yet_accepted?
+        email_change.each do |to_address|
+          UserMailer.delay.email_changed_by_admin_notification(@user, email_change.first, to_address)
+        end
+      end
 
       redirect_to admin_users_path, notice: "Updated user #{@user.email} successfully"
     else

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -23,6 +23,7 @@ class Admin::UsersController < ApplicationController
       PermissionUpdater.perform_on(@user)
 
       if email_change = @user.previous_changes[:email]
+        EventLog.record_event(@user, EventLog::EMAIL_CHANGE_INITIATIED, current_user)
         @user.invite! if @user.invited_but_not_yet_accepted?
         email_change.each do |to_address|
           UserMailer.delay.email_changed_by_admin_notification(@user, email_change.first, to_address)

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -18,6 +18,7 @@ class ConfirmationsController < Devise::ConfirmationsController
       else
         self.resource = resource_class.confirm_by_token(params[:confirmation_token])
         if resource.errors.empty?
+          EventLog.record_event(resource, EventLog::EMAIL_CHANGE_CONFIRMED)
           set_flash_message(:notice, :confirmed) if is_navigational_format?
           sign_in(resource_name, resource)
           respond_with_navigational(resource){ redirect_to after_confirmation_path_for(resource_name, resource) }
@@ -38,6 +39,7 @@ class ConfirmationsController < Devise::ConfirmationsController
     if self.resource.valid_password?(params[:user][:password])
       self.resource = resource_class.confirm_by_token(params[:confirmation_token])
       if resource.errors.empty?
+        EventLog.record_event(resource, EventLog::EMAIL_CHANGE_CONFIRMED)
         set_flash_message(:notice, :confirmed) if is_navigational_format?
         sign_in(resource_name, resource)
         respond_with_navigational(resource){ redirect_to after_confirmation_path_for(resource_name, resource) }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,6 +21,7 @@ class UsersController < ApplicationController
       flash[:alert] = "Nothing to update."
       render :edit
     elsif current_user.update_attributes(email: params[:user][:email])
+      EventLog.record_event(current_user, EventLog::EMAIL_CHANGE_INITIATIED, current_user)
       redirect_to root_path, notice: "An email has been sent to #{params[:user][:email]}. Follow the link in the email to update your address."
     else
       flash[:alert] = "Failed to change email."

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -23,6 +23,11 @@ class UserMailer < ActionMailer::Base
     mail(to: @user.email, subject: suspension_notification_subject)
   end
 
+  def email_changed_by_admin_notification(user, email_was, to_address)
+    @user, @email_was = user, email_was
+    mail(to: to_address, subject: 'Your email has been updated')
+  end
+
 private
   def suspension_time
     if @days == 1

--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -11,6 +11,8 @@ class EventLog < ActiveRecord::Base
   UNSUCCESSFUL_LOGIN = "Unsuccessful login"
   SUSPENDED_ACCOUNT_AUTHENTICATED_LOGIN = "Unsuccessful login attempt to a suspended account, with the correct username and password"
   UNSUCCESSFUL_PASSPHRASE_CHANGE = "Unsuccessful passphrase change"
+  EMAIL_CHANGE_INITIATIED = "Email change initiated"
+  EMAIL_CHANGE_CONFIRMED = "Email change confirmed"
 
   # API users
   API_USER_CREATED = "Account created"
@@ -23,7 +25,8 @@ class EventLog < ActiveRecord::Base
                                 MANUAL_ACCOUNT_UNLOCK,
                                 API_USER_CREATED,
                                 ACCESS_TOKEN_GENERATED,
-                                ACCESS_TOKEN_REVOKED]
+                                ACCESS_TOKEN_REVOKED,
+                                EMAIL_CHANGE_INITIATIED]
 
   EVENTS_REQUIRING_APPLICATION_ID = [ACCESS_TOKEN_REGENERATED, ACCESS_TOKEN_GENERATED, ACCESS_TOKEN_REVOKED]
 

--- a/app/views/user_mailer/email_changed_by_admin_notification.html.erb
+++ b/app/views/user_mailer/email_changed_by_admin_notification.html.erb
@@ -1,0 +1,12 @@
+<p>Hello <%= @user.name %>,</p>
+
+<p>A Signon administrator has changed your <%= link_to 'GOV.UK', 'https://www.gov.uk' %> Signon <%= account_name %> email from <%= @email_was %> to <%= @user.email %>.</p>
+
+<p>You will now need to <%= link_to 'sign in', new_user_session_url(protocol: 'https') %> using your new email <%= @user.email %>.</p>
+
+<p>If your email address shouldn't have changed you should contact a managing GOV.UK editor in your organisation or your parent organisation.</p>
+
+<p>All the best,</p>
+
+<p><%= link_to 'GOV.UK', 'https://www.gov.uk' %> team</p>
+<p>Government Digital Service</p>

--- a/app/views/user_mailer/email_changed_by_admin_notification.text.erb
+++ b/app/views/user_mailer/email_changed_by_admin_notification.text.erb
@@ -1,0 +1,12 @@
+Hello <%= @user.name %>,
+
+A Signon administrator has changed your GOV.UK Signon <%= account_name %> email from <%= @email_was %> to <%= @user.email %>.
+
+You will now need to sign in using your new email <%= @user.email %>.
+
+If your email address shouldn't have changed you should contact a managing GOV.UK editor in your organisation or your parent organisation.
+
+All the best,
+
+GOV.UK team
+Government Digital Service

--- a/test/functional/admin/users_controller_test.rb
+++ b/test/functional/admin/users_controller_test.rb
@@ -273,26 +273,37 @@ class Admin::UsersControllerTest < ActionController::TestCase
     end
 
     context "changing an email" do
-      should "stage the change, and send a confirmation email" do
-        another_user = create(:user, email: "old@email.com")
-        put :update, id: another_user.id, user: { email: "new@email.com" }
+      should "not re-confirm email" do
+        normal_user = create(:user, email: "old@email.com")
+        put :update, id: normal_user.id, user: { email: "new@email.com" }
 
-        another_user.reload
-        assert_equal "new@email.com", another_user.reload.unconfirmed_email
-        assert_equal "old@email.com", another_user.reload.email
-        assert_equal "Confirm your email change", ActionMailer::Base.deliveries.last.subject
+        assert_nil normal_user.reload.unconfirmed_email
+        assert_equal "new@email.com", normal_user.email
+      end
+
+      should "send email change notifications to old and new email address" do
+        Sidekiq::Testing.inline! do
+          normal_user = create(:user, email: "old@email.com")
+          put :update, id: normal_user.id, user: { email: "new@email.com" }
+
+          email_change_notifications = ActionMailer::Base.deliveries[-2..-1]
+          assert_equal ['Your email has been updated'], email_change_notifications.map(&:subject).uniq
+          assert_equal %w(old@email.com new@email.com), email_change_notifications.map {|mail| mail.to.first }
+        end
       end
 
       context "an invited-but-not-yet-accepted user" do
-        should "change the email, and send a new invitation email" do
-          another_user = User.invite!(name: "Ali", email: "old@email.com")
-          put :update, id: another_user.id, user: { email: "new@email.com" }
+        should "change the email, and send an invitation email" do
+          Sidekiq::Testing.inline! do
+            another_user = User.invite!(name: "Ali", email: "old@email.com")
+            put :update, id: another_user.id, user: { email: "new@email.com" }
 
-          another_user.reload
-          assert_equal "new@email.com", another_user.reload.email
-          signup_email = ActionMailer::Base.deliveries.last
-          assert_equal "Please confirm your account", signup_email.subject
-          assert_equal "new@email.com", signup_email.to[0]
+            another_user.reload
+            assert_equal "new@email.com", another_user.reload.email
+            invitation_email = ActionMailer::Base.deliveries[-3]
+            assert_equal "Please confirm your account", invitation_email.subject
+            assert_equal "new@email.com", invitation_email.to.first
+          end
         end
       end
     end

--- a/test/functional/admin/users_controller_test.rb
+++ b/test/functional/admin/users_controller_test.rb
@@ -281,6 +281,13 @@ class Admin::UsersControllerTest < ActionController::TestCase
         assert_equal "new@email.com", normal_user.email
       end
 
+      should "log an event" do
+        normal_user = create(:user, email: "old@email.com")
+        put :update, id: normal_user.id, user: { email: "new@email.com" }
+
+        assert_equal 1, EventLog.where(event: EventLog::EMAIL_CHANGE_INITIATIED, uid: normal_user.uid, initiator_id: @user.id).count
+      end
+
       should "send email change notifications to old and new email address" do
         Sidekiq::Testing.inline! do
           normal_user = create(:user, email: "old@email.com")

--- a/test/functional/confirmations_controller_test.rb
+++ b/test/functional/confirmations_controller_test.rb
@@ -60,6 +60,11 @@ class ConfirmationsControllerTest < ActionController::TestCase
         assert_redirected_to "/"
         assert_equal @user.reload.email, "new@email.com"
       end
+
+      should "log an event upon confirmation" do
+        get :show, confirmation_token: @user.confirmation_token
+        assert_equal 1, EventLog.where(event: EventLog::EMAIL_CHANGE_CONFIRMED, uid: @user.uid).count
+      end
     end
 
     context "signed in as somebody else" do
@@ -84,6 +89,13 @@ class ConfirmationsControllerTest < ActionController::TestCase
       assert_redirected_to "/"
       assert @controller.user_signed_in?
       assert_equal @user.reload.email, "new@email.com"
+    end
+
+    should "log an event upon confirmation" do
+      put :update,
+            confirmation_token: @user.confirmation_token,
+            user: { password: "this 1s 4 v3333ry s3cur3 p4ssw0rd.!Z" }
+      assert_equal 1, EventLog.where(event: EventLog::EMAIL_CHANGE_CONFIRMED, uid: @user.uid).count
     end
 
     should "reject with an incorrect token" do

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -83,6 +83,11 @@ class UsersControllerTest < ActionController::TestCase
         assert_equal "Confirm your email change", email.subject
         assert_equal "new@email.com", email.to[0]
       end
+
+      should "log an event" do
+        put :update, user: { email: "new@email.com" }
+        assert_equal 1, EventLog.where(event: EventLog::EMAIL_CHANGE_INITIATIED, uid: @user.uid, initiator_id: @user.id).count
+      end
     end
   end
 


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/6192

for users who have moved from one organisation to another, and consequently have an updated email in Signon, resetting their password is confusing.

they won't receive password reset instructions on their new email if they've not confirmed it yet. sending reset instructions to their old address works, but on most occasions they would have lost access to the old address by then.

hence, we're skipping re-confirmation when an admin updates a user's email address and instead we send a notification to a user's old and new email address informing them about the update.

also adding events to the users access log when email is changed and the change is accepted.

notification email text:

> Hello Louisa Lockwood,

> A Signon administrator has changed your GOV.UK Signon account email from louisa.lockwood@example.gov.uk to louisa.lockwood@new-example.gov.uk.

> You will now need to sign in using your new email louisa.lockwood@new-example.gov.uk.

> If your email address shouldn't have changed you should contact a managing GOV.UK editor in your organisation or your parent organisation.

> All the best,

> GOV.UK team
> Government Digital Service