### PR TITLE
Allow passing options to EventLog

### DIFF
--- a/app/controllers/admin/suspensions_controller.rb
+++ b/app/controllers/admin/suspensions_controller.rb
@@ -17,7 +17,7 @@ class Admin::SuspensionsController < ApplicationController
     end
 
     if succeeded
-      EventLog.record_event(@user, action, current_user)
+      EventLog.record_event(@user, action, initiator: current_user)
       PermissionUpdater.perform_on(@user)
       ReauthEnforcer.perform_on(@user)
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -23,7 +23,7 @@ class Admin::UsersController < ApplicationController
       PermissionUpdater.perform_on(@user)
 
       if email_change = @user.previous_changes[:email]
-        EventLog.record_event(@user, EventLog::EMAIL_CHANGE_INITIATIED, current_user)
+        EventLog.record_event(@user, EventLog::EMAIL_CHANGE_INITIATIED, initiator: current_user)
         @user.invite! if @user.invited_but_not_yet_accepted?
         email_change.each do |to_address|
           UserMailer.delay.email_changed_by_admin_notification(@user, email_change.first, to_address)
@@ -37,7 +37,7 @@ class Admin::UsersController < ApplicationController
   end
 
   def unlock
-    EventLog.record_event(@user, EventLog::MANUAL_ACCOUNT_UNLOCK, current_user)
+    EventLog.record_event(@user, EventLog::MANUAL_ACCOUNT_UNLOCK, initiator: current_user)
     @user.unlock_access!
     flash[:notice] = "Unlocked #{@user.email}"
     redirect_to :back

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -23,7 +23,7 @@ class Admin::UsersController < ApplicationController
       PermissionUpdater.perform_on(@user)
 
       if email_change = @user.previous_changes[:email]
-        EventLog.record_event(@user, EventLog::EMAIL_CHANGE_INITIATIED, initiator: current_user)
+        EventLog.record_email_change(@user, email_change.first, email_change.last, current_user)
         @user.invite! if @user.invited_but_not_yet_accepted?
         email_change.each do |to_address|
           UserMailer.delay.email_changed_by_admin_notification(@user, email_change.first, to_address)

--- a/app/controllers/superadmin/api_users_controller.rb
+++ b/app/controllers/superadmin/api_users_controller.rb
@@ -20,7 +20,7 @@ class Superadmin::ApiUsersController < ApplicationController
     @api_user.api_user = true
 
     if @api_user.save
-      EventLog.record_event(@api_user, EventLog::API_USER_CREATED, current_user)
+      EventLog.record_event(@api_user, EventLog::API_USER_CREATED, initiator: current_user)
       redirect_to [:edit, :superadmin, @api_user], notice: "Successfully created API user"
     else
       render :new

--- a/app/controllers/superadmin/authorisations_controller.rb
+++ b/app/controllers/superadmin/authorisations_controller.rb
@@ -20,7 +20,7 @@ class Superadmin::AuthorisationsController < ApplicationController
       application_permission.permissions << "signin" unless application_permission.permissions.include?("signin")
       application_permission.save!
 
-      EventLog.record_event(@api_user, EventLog::ACCESS_TOKEN_GENERATED, current_user, authorisation.application)
+      EventLog.record_event(@api_user, EventLog::ACCESS_TOKEN_GENERATED, initiator: current_user, application: authorisation.application)
       flash[:authorisation] = { application_name: authorisation.application.name, token: authorisation.token }
     else
       flash[:error] = "There was an error while creating the access token"
@@ -35,11 +35,11 @@ class Superadmin::AuthorisationsController < ApplicationController
         regenerated_authorisation = @api_user.authorisations.create!(expires_in: ApiUser::DEFAULT_TOKEN_LIFE,
                                                                       application_id: authorisation.application_id)
 
-        EventLog.record_event(@api_user, EventLog::ACCESS_TOKEN_REGENERATED, current_user, authorisation.application)
+        EventLog.record_event(@api_user, EventLog::ACCESS_TOKEN_REGENERATED, initiator: current_user, application: authorisation.application)
         flash[:authorisation] = { application_name: regenerated_authorisation.application.name,
                                   token: regenerated_authorisation.token }
       else
-        EventLog.record_event(@api_user, EventLog::ACCESS_TOKEN_REVOKED, current_user, authorisation.application)
+        EventLog.record_event(@api_user, EventLog::ACCESS_TOKEN_REVOKED, initiator: current_user, application: authorisation.application)
         flash[:notice] = "Access for #{authorisation.application.name} was revoked"
       end
     else

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,12 +17,13 @@ class UsersController < ApplicationController
   end
 
   def update
-    if current_user.email == params[:user][:email].strip
+    current_email, new_email = current_user.email, params[:user][:email]
+    if current_email == new_email.strip
       flash[:alert] = "Nothing to update."
       render :edit
-    elsif current_user.update_attributes(email: params[:user][:email])
-      EventLog.record_event(current_user, EventLog::EMAIL_CHANGE_INITIATIED, initiator: current_user)
-      redirect_to root_path, notice: "An email has been sent to #{params[:user][:email]}. Follow the link in the email to update your address."
+    elsif current_user.update_attributes(email: new_email)
+      EventLog.record_email_change(current_user, current_email, new_email)
+      redirect_to root_path, notice: "An email has been sent to #{new_email}. Follow the link in the email to update your address."
     else
       flash[:alert] = "Failed to change email."
       render :edit

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,7 +21,7 @@ class UsersController < ApplicationController
       flash[:alert] = "Nothing to update."
       render :edit
     elsif current_user.update_attributes(email: params[:user][:email])
-      EventLog.record_event(current_user, EventLog::EMAIL_CHANGE_INITIATIED, current_user)
+      EventLog.record_event(current_user, EventLog::EMAIL_CHANGE_INITIATIED, initiator: current_user)
       redirect_to root_path, notice: "An email has been sent to #{params[:user][:email]}. Follow the link in the email to update your address."
     else
       flash[:alert] = "Failed to change email."

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -20,4 +20,5 @@ module UsersHelper
   def edit_user_path_by_user_type(user)
     user.api_user? ? edit_superadmin_api_user_path(user) : edit_admin_user_path(user)
   end
+
 end

--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -11,7 +11,8 @@ class EventLog < ActiveRecord::Base
   UNSUCCESSFUL_LOGIN = "Unsuccessful login"
   SUSPENDED_ACCOUNT_AUTHENTICATED_LOGIN = "Unsuccessful login attempt to a suspended account, with the correct username and password"
   UNSUCCESSFUL_PASSPHRASE_CHANGE = "Unsuccessful passphrase change"
-  EMAIL_CHANGE_INITIATED = "Email changed"
+  EMAIL_CHANGED = "Email changed"
+  EMAIL_CHANGE_INITIATED = "Email change initiated"
   EMAIL_CHANGE_CONFIRMED = "Email change confirmed"
 
   # API users
@@ -26,7 +27,7 @@ class EventLog < ActiveRecord::Base
                                 API_USER_CREATED,
                                 ACCESS_TOKEN_GENERATED,
                                 ACCESS_TOKEN_REVOKED,
-                                EMAIL_CHANGE_INITIATED]
+                                EMAIL_CHANGED]
 
   EVENTS_REQUIRING_APPLICATION_ID = [ACCESS_TOKEN_REGENERATED, ACCESS_TOKEN_GENERATED, ACCESS_TOKEN_REVOKED]
   VALID_OPTIONS = [:initiator, :application, :trailing_message]
@@ -45,7 +46,8 @@ class EventLog < ActiveRecord::Base
   end
 
   def self.record_email_change(user, email_was, email_is, initiator=user)
-    record_event(user, EMAIL_CHANGE_INITIATED, initiator: initiator, trailing_message: "from #{email_was} to #{email_is}")
+    event = (user == initiator) ? EMAIL_CHANGE_INITIATED : EMAIL_CHANGED
+    record_event(user, event, initiator: initiator, trailing_message: "from #{email_was} to #{email_is}")
   end
 
   def self.for(user)

--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -29,6 +29,7 @@ class EventLog < ActiveRecord::Base
                                 EMAIL_CHANGE_INITIATIED]
 
   EVENTS_REQUIRING_APPLICATION_ID = [ACCESS_TOKEN_REGENERATED, ACCESS_TOKEN_GENERATED, ACCESS_TOKEN_REVOKED]
+  VALID_OPTIONS = [:initiator, :application]
 
   validates :uid, presence: true
   validates :event, presence: true
@@ -38,11 +39,8 @@ class EventLog < ActiveRecord::Base
   belongs_to :initiator, class_name: "User"
   belongs_to :application, class_name: "Doorkeeper::Application"
 
-  def self.record_event(user, event, initiator = nil, application = nil)
-    attributes = { uid: user.uid, event: event }
-    attributes.merge!(initiator_id: initiator.id) if initiator
-    attributes.merge!(application_id: application.id) if application
-
+  def self.record_event(user, event, options={})
+    attributes = { uid: user.uid, event: event }.merge!(options.slice(*VALID_OPTIONS))
     EventLog.create(attributes)
   end
 

--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -11,7 +11,7 @@ class EventLog < ActiveRecord::Base
   UNSUCCESSFUL_LOGIN = "Unsuccessful login"
   SUSPENDED_ACCOUNT_AUTHENTICATED_LOGIN = "Unsuccessful login attempt to a suspended account, with the correct username and password"
   UNSUCCESSFUL_PASSPHRASE_CHANGE = "Unsuccessful passphrase change"
-  EMAIL_CHANGE_INITIATIED = "Email change initiated"
+  EMAIL_CHANGE_INITIATIED = "Email changed"
   EMAIL_CHANGE_CONFIRMED = "Email change confirmed"
 
   # API users
@@ -29,7 +29,7 @@ class EventLog < ActiveRecord::Base
                                 EMAIL_CHANGE_INITIATIED]
 
   EVENTS_REQUIRING_APPLICATION_ID = [ACCESS_TOKEN_REGENERATED, ACCESS_TOKEN_GENERATED, ACCESS_TOKEN_REVOKED]
-  VALID_OPTIONS = [:initiator, :application]
+  VALID_OPTIONS = [:initiator, :application, :trailing_message]
 
   validates :uid, presence: true
   validates :event, presence: true
@@ -42,6 +42,10 @@ class EventLog < ActiveRecord::Base
   def self.record_event(user, event, options={})
     attributes = { uid: user.uid, event: event }.merge!(options.slice(*VALID_OPTIONS))
     EventLog.create(attributes)
+  end
+
+  def self.record_email_change(user, email_was, email_is, initiator=user)
+    record_event(user, EMAIL_CHANGE_INITIATIED, initiator: initiator, trailing_message: "from #{email_was} to #{email_is}")
   end
 
   def self.for(user)

--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -11,7 +11,7 @@ class EventLog < ActiveRecord::Base
   UNSUCCESSFUL_LOGIN = "Unsuccessful login"
   SUSPENDED_ACCOUNT_AUTHENTICATED_LOGIN = "Unsuccessful login attempt to a suspended account, with the correct username and password"
   UNSUCCESSFUL_PASSPHRASE_CHANGE = "Unsuccessful passphrase change"
-  EMAIL_CHANGE_INITIATIED = "Email changed"
+  EMAIL_CHANGE_INITIATED = "Email changed"
   EMAIL_CHANGE_CONFIRMED = "Email change confirmed"
 
   # API users
@@ -26,7 +26,7 @@ class EventLog < ActiveRecord::Base
                                 API_USER_CREATED,
                                 ACCESS_TOKEN_GENERATED,
                                 ACCESS_TOKEN_REVOKED,
-                                EMAIL_CHANGE_INITIATIED]
+                                EMAIL_CHANGE_INITIATED]
 
   EVENTS_REQUIRING_APPLICATION_ID = [ACCESS_TOKEN_REGENERATED, ACCESS_TOKEN_GENERATED, ACCESS_TOKEN_REVOKED]
   VALID_OPTIONS = [:initiator, :application, :trailing_message]
@@ -45,7 +45,7 @@ class EventLog < ActiveRecord::Base
   end
 
   def self.record_email_change(user, email_was, email_is, initiator=user)
-    record_event(user, EMAIL_CHANGE_INITIATIED, initiator: initiator, trailing_message: "from #{email_was} to #{email_is}")
+    record_event(user, EMAIL_CHANGE_INITIATED, initiator: initiator, trailing_message: "from #{email_was} to #{email_is}")
   end
 
   def self.for(user)

--- a/app/views/admin/event_logs/index.html.erb
+++ b/app/views/admin/event_logs/index.html.erb
@@ -32,6 +32,7 @@
             <% if log.initiator %>
               by <strong><%= link_to log.initiator.name, admin_users_path(filter: log.initiator.email), title: log.initiator.email %></strong>
             <% end %>
+            <%= log.trailing_message %>
           </td>
         </tr>
       <% end %>

--- a/db/migrate/20150107063935_add_trailing_message_to_event_logs.rb
+++ b/db/migrate/20150107063935_add_trailing_message_to_event_logs.rb
@@ -1,0 +1,5 @@
+class AddTrailingMessageToEventLogs < ActiveRecord::Migration
+  def change
+    add_column :event_logs, :trailing_message, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20140917091319) do
+ActiveRecord::Schema.define(:version => 201210051824050) do
 
   create_table "batch_invitation_users", :force => true do |t|
     t.integer  "batch_invitation_id"
@@ -36,11 +36,12 @@ ActiveRecord::Schema.define(:version => 20140917091319) do
   add_index "batch_invitations", ["outcome"], :name => "index_batch_invitations_on_outcome"
 
   create_table "event_logs", :force => true do |t|
-    t.string   "uid",            :null => false
-    t.string   "event",          :null => false
-    t.datetime "created_at",     :null => false
+    t.string   "uid",              :null => false
+    t.string   "event",            :null => false
+    t.datetime "created_at",       :null => false
     t.integer  "initiator_id"
     t.integer  "application_id"
+    t.string   "trailing_message"
   end
 
   add_index "event_logs", ["uid", "created_at"], :name => "index_event_logs_on_uid_and_created_at"

--- a/test/functional/admin/users_controller_test.rb
+++ b/test/functional/admin/users_controller_test.rb
@@ -285,7 +285,7 @@ class Admin::UsersControllerTest < ActionController::TestCase
         normal_user = create(:user, email: "old@email.com")
         put :update, id: normal_user.id, user: { email: "new@email.com" }
 
-        assert_equal 1, EventLog.where(event: EventLog::EMAIL_CHANGE_INITIATIED, uid: normal_user.uid, initiator_id: @user.id).count
+        assert_equal 1, EventLog.where(event: EventLog::EMAIL_CHANGE_INITIATED, uid: normal_user.uid, initiator_id: @user.id).count
       end
 
       should "send email change notifications to old and new email address" do

--- a/test/functional/admin/users_controller_test.rb
+++ b/test/functional/admin/users_controller_test.rb
@@ -285,7 +285,7 @@ class Admin::UsersControllerTest < ActionController::TestCase
         normal_user = create(:user, email: "old@email.com")
         put :update, id: normal_user.id, user: { email: "new@email.com" }
 
-        assert_equal 1, EventLog.where(event: EventLog::EMAIL_CHANGE_INITIATED, uid: normal_user.uid, initiator_id: @user.id).count
+        assert_equal 1, EventLog.where(event: EventLog::EMAIL_CHANGED, uid: normal_user.uid, initiator_id: @user.id).count
       end
 
       should "send email change notifications to old and new email address" do

--- a/test/functional/superadmin/api_users_controller_test.rb
+++ b/test/functional/superadmin/api_users_controller_test.rb
@@ -52,7 +52,7 @@ class Superadmin::ApiUsersControllerTest < ActionController::TestCase
 
       should "log API user created event in the api users event log" do
         EventLog.stubs(:record_event) # to ignore logs being created, other than the one under test
-        EventLog.expects(:record_event).with(instance_of(ApiUser), EventLog::API_USER_CREATED, @superadmin)
+        EventLog.expects(:record_event).with(instance_of(ApiUser), EventLog::API_USER_CREATED, initiator: @superadmin)
 
         post :create, api_user: { name: "Content Store Application", email: "content.store@gov.uk" }
       end

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -86,7 +86,7 @@ class UsersControllerTest < ActionController::TestCase
 
       should "log an event" do
         put :update, user: { email: "new@email.com" }
-        assert_equal 1, EventLog.where(event: EventLog::EMAIL_CHANGE_INITIATIED, uid: @user.uid, initiator_id: @user.id).count
+        assert_equal 1, EventLog.where(event: EventLog::EMAIL_CHANGE_INITIATED, uid: @user.uid, initiator_id: @user.id).count
       end
     end
   end

--- a/test/integration/email_change_test.rb
+++ b/test/integration/email_change_test.rb
@@ -120,7 +120,7 @@ class EmailChangeTest < ActionDispatch::IntegrationTest
       signout
       signin(create(:admin_user))
       visit admin_user_event_logs_path(@user)
-      assert_response_contains "Email changed by #{@user.name} from original@email.com to new@email.com"
+      assert_response_contains "Email change initiated by #{@user.name} from original@email.com to new@email.com"
       assert_response_contains "Email change confirmed"
     end
 

--- a/test/integration/email_change_test.rb
+++ b/test/integration/email_change_test.rb
@@ -23,6 +23,19 @@ class EmailChangeTest < ActionDispatch::IntegrationTest
         end
       end
 
+      should "log the event in the user's event log" do
+        Sidekiq::Testing.inline! do
+          user = create(:user, email: 'old@email.com')
+
+          visit new_user_session_path
+          signin(@admin)
+          admin_changes_email_address(user: user, new_email: "new@email.com")
+
+          visit admin_user_event_logs_path(user)
+          assert_response_contains "Email changed by #{@admin.name} from old@email.com to new@email.com"
+        end
+      end
+
       should "show an error and not trigger a notification if the email is blank" do
         user = create(:user)
 
@@ -92,6 +105,23 @@ class EmailChangeTest < ActionDispatch::IntegrationTest
 
       assert_equal "new@email.com", last_email.to[0]
       assert_equal 'Confirm your email change', last_email.subject
+    end
+
+    should "log email change events in the user's event log" do
+      visit new_user_session_path
+      signin(@user)
+
+      visit edit_user_path(@user)
+      fill_in "Email", with: "new@email.com"
+      click_button "Change email"
+
+      visit user_confirmation_path(confirmation_token: @user.reload.confirmation_token)
+
+      signout
+      signin(create(:admin_user))
+      visit admin_user_event_logs_path(@user)
+      assert_response_contains "Email changed by #{@user.name} from original@email.com to new@email.com"
+      assert_response_contains "Email change confirmed"
     end
 
     should "show an error and not send a confirmation if the email is blank" do

--- a/test/unit/event_log_test.rb
+++ b/test/unit/event_log_test.rb
@@ -25,6 +25,24 @@ class EventLogTest < ActiveSupport::TestCase
     assert EventLog.record_event(create(:user), :event).valid?
   end
 
+  context ".record_email_change" do
+    should "record email change events with a trailing message" do
+      user = create(:user, email: 'new@example.com')
+      event_log = EventLog.record_email_change(user, 'old@example.com', user.email)
+
+      assert_equal user.uid, event_log.uid
+      assert_equal user.id, event_log.initiator_id
+      assert_equal 'from old@example.com to new@example.com', event_log.trailing_message
+    end
+
+    should "record the initiator when initiator is other than the user" do
+      user, admin = create(:user, email: 'new@example.com'), create(:admin_user)
+      event_log = EventLog.record_email_change(user, 'old@example.com', user.email, admin)
+
+      assert_equal admin.id, event_log.initiator_id
+    end
+  end
+
   test "records the initiator of the event passed as an option" do
     initiator = create(:admin_user)
     EventLog.record_event(create(:user), :event, initiator: initiator)

--- a/test/unit/event_log_test.rb
+++ b/test/unit/event_log_test.rb
@@ -26,6 +26,20 @@ class EventLogTest < ActiveSupport::TestCase
   end
 
   context ".record_email_change" do
+    should "record event EMAIL_CHANGED when initiator is an admin" do
+      user = create(:user, email: 'new@example.com')
+      event_log = EventLog.record_email_change(user, 'old@example.com', user.email, create(:admin_user))
+
+      assert_equal EventLog::EMAIL_CHANGED, event_log.event
+    end
+
+    should "record event EMAIL_CHANGE_INITIATED when a user is changing their own email" do
+      user = create(:user, email: 'new@example.com')
+      event_log = EventLog.record_email_change(user, 'old@example.com', user.email)
+
+      assert_equal EventLog::EMAIL_CHANGE_INITIATED, event_log.event
+    end
+
     should "record email change events with a trailing message" do
       user = create(:user, email: 'new@example.com')
       event_log = EventLog.record_email_change(user, 'old@example.com', user.email)

--- a/test/unit/event_log_test.rb
+++ b/test/unit/event_log_test.rb
@@ -25,18 +25,25 @@ class EventLogTest < ActiveSupport::TestCase
     assert EventLog.record_event(create(:user), :event).valid?
   end
 
-  test "optionally records the initiator of the event" do
+  test "records the initiator of the event passed as an option" do
     initiator = create(:admin_user)
-    EventLog.record_event(create(:user), :event, initiator)
+    EventLog.record_event(create(:user), :event, initiator: initiator)
 
     assert_equal initiator, EventLog.last.initiator
   end
 
-  test "optionally records the application associated with the event" do
+  test "records the application associated with the event passed as an option" do
     application = create(:application)
-    EventLog.record_event(create(:user), :event, nil, application)
+    EventLog.record_event(create(:user), :event, application: application)
 
     assert_equal application, EventLog.last.application
+  end
+
+  test "skips invalid options passed" do
+    user = create(:user)
+    EventLog.record_event(user, :event, uid: build(:user).uid)
+
+    assert_equal user.uid, EventLog.last.uid
   end
 
   test "can use a helper to fetch all logs for a user" do


### PR DESCRIPTION
This makes `EventLog` flexible to addition of parameters and removes the need to pass `nil` as a parameter on occasions when trailing parameters need to be passed.

Adds a new attribute on `EventLog`: `trailing_message`, which allows us to record additional attributes about the event as a free-form string. Includes the first use of `trailing_message` in order to record old and new email address when the email is changed.