### PR TITLE
User email change should be notified at old email

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -23,6 +23,7 @@ class UsersController < ApplicationController
       render :edit
     elsif current_user.update_attributes(email: new_email)
       EventLog.record_email_change(current_user, current_email, new_email)
+      UserMailer.email_changed_notification(current_user).deliver
       redirect_to root_path, notice: "An email has been sent to #{new_email}. Follow the link in the email to update your address."
     else
       flash[:alert] = "Failed to change email."

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -25,12 +25,12 @@ class UserMailer < ActionMailer::Base
 
   def email_changed_by_admin_notification(user, email_was, to_address)
     @user, @email_was = user, email_was
-    mail(to: to_address, subject: 'Your email has been updated')
+    mail(to: to_address, subject: "Your #{app_name} email has been updated")
   end
 
   def email_changed_notification(user)
     @user = user
-    mail(to: @user.email, subject: 'Your email is being changed')
+    mail(to: @user.email, subject: "Your #{app_name} email is being changed")
   end
 
 private

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -28,6 +28,11 @@ class UserMailer < ActionMailer::Base
     mail(to: to_address, subject: 'Your email has been updated')
   end
 
+  def email_changed_notification(user)
+    @user = user
+    mail(to: @user.email, subject: 'Your email is being changed')
+  end
+
 private
   def suspension_time
     if @days == 1

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -25,12 +25,12 @@ class UserMailer < ActionMailer::Base
 
   def email_changed_by_admin_notification(user, email_was, to_address)
     @user, @email_was = user, email_was
-    mail(to: to_address, subject: "Your #{app_name} email has been updated")
+    mail(to: to_address, subject: "Your #{app_name} email address has been updated")
   end
 
   def email_changed_notification(user)
     @user = user
-    mail(to: @user.email, subject: "Your #{app_name} email is being changed")
+    mail(to: @user.email, subject: "Your #{app_name} email address is being changed")
   end
 
 private

--- a/app/views/user_mailer/email_changed_notification.html.erb
+++ b/app/views/user_mailer/email_changed_notification.html.erb
@@ -1,8 +1,8 @@
 <p>Hello <%= @user.name %>,</p>
 
-<p>Your <%= link_to 'GOV.UK', 'https://www.gov.uk' %> Signon <%= account_name %> email is being changed from <%= @user.email %> to <%= @user.unconfirmed_email %>.</p>
+<p>Your <%= link_to 'GOV.UK', 'https://www.gov.uk' %> Signon <%= account_name %> email address is being changed from <%= @user.email %> to <%= @user.unconfirmed_email %>.</p>
 
-<p>You are required to follow the instructions sent on your new email <%= @user.email %> to confirm this change.</p>
+<p>You should follow the instructions sent to your new email address: <%= @user.email %> to confirm this change.</p>
 
 <p>If your email address shouldn't have changed you should contact a managing GOV.UK editor in your organisation or your parent organisation.</p>
 

--- a/app/views/user_mailer/email_changed_notification.html.erb
+++ b/app/views/user_mailer/email_changed_notification.html.erb
@@ -1,0 +1,12 @@
+<p>Hello <%= @user.name %>,</p>
+
+<p>Your <%= link_to 'GOV.UK', 'https://www.gov.uk' %> Signon <%= account_name %> email is being changed from <%= @user.email %> to <%= @user.unconfirmed_email %>.</p>
+
+<p>You are required to follow the instructions sent on your new email <%= @user.email %> to confirm this change.</p>
+
+<p>If your email address shouldn't have changed you should contact a managing GOV.UK editor in your organisation or your parent organisation.</p>
+
+<p>All the best,</p>
+
+<p><%= link_to 'GOV.UK', 'https://www.gov.uk' %> team</p>
+<p>Government Digital Service</p>

--- a/app/views/user_mailer/email_changed_notification.text.erb
+++ b/app/views/user_mailer/email_changed_notification.text.erb
@@ -1,0 +1,12 @@
+Hello <%= @user.name %>,
+
+Your GOV.UK Signon <%= account_name %> email is being changed from <%= @user.email %> to <%= @user.unconfirmed_email %>.
+
+You are required to follow the instructions sent on your new email <%= @user.email %> to confirm this change.
+
+If your email address shouldn't have changed you should contact a managing GOV.UK editor in your organisation or your parent organisation.
+
+All the best,
+
+GOV.UK team
+Government Digital Service

--- a/app/views/user_mailer/email_changed_notification.text.erb
+++ b/app/views/user_mailer/email_changed_notification.text.erb
@@ -1,8 +1,8 @@
 Hello <%= @user.name %>,
 
-Your GOV.UK Signon <%= account_name %> email is being changed from <%= @user.email %> to <%= @user.unconfirmed_email %>.
+Your GOV.UK Signon <%= account_name %> email address is being changed from <%= @user.email %> to <%= @user.unconfirmed_email %>.
 
-You are required to follow the instructions sent on your new email <%= @user.email %> to confirm this change.
+You should follow the instructions sent to your new email address: <%= @user.email %> to confirm this change.
 
 If your email address shouldn't have changed you should contact a managing GOV.UK editor in your organisation or your parent organisation.
 

--- a/test/functional/admin/users_controller_test.rb
+++ b/test/functional/admin/users_controller_test.rb
@@ -320,7 +320,7 @@ class Admin::UsersControllerTest < ActionController::TestCase
           put :update, id: normal_user.id, user: { email: "new@email.com" }
 
           email_change_notifications = ActionMailer::Base.deliveries[-2..-1]
-          assert_equal ['Your email has been updated'], email_change_notifications.map(&:subject).uniq
+          assert_equal ['Your GOV.UK Signon email has been updated'], email_change_notifications.map(&:subject).uniq
           assert_equal %w(old@email.com new@email.com), email_change_notifications.map {|mail| mail.to.first }
         end
       end

--- a/test/functional/admin/users_controller_test.rb
+++ b/test/functional/admin/users_controller_test.rb
@@ -320,7 +320,7 @@ class Admin::UsersControllerTest < ActionController::TestCase
           put :update, id: normal_user.id, user: { email: "new@email.com" }
 
           email_change_notifications = ActionMailer::Base.deliveries[-2..-1]
-          assert_equal ['Your GOV.UK Signon email has been updated'], email_change_notifications.map(&:subject).uniq
+          assert_equal ['Your GOV.UK Signon email address has been updated'], email_change_notifications.map(&:subject).uniq
           assert_equal %w(old@email.com new@email.com), email_change_notifications.map {|mail| mail.to.first }
         end
       end

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -84,7 +84,7 @@ class UsersControllerTest < ActionController::TestCase
         assert_equal "new@email.com", confirmation_email.to.first
 
         email_changed_notification = ActionMailer::Base.deliveries.last
-        assert_equal "Your GOV.UK Signon email is being changed", email_changed_notification.subject
+        assert_equal "Your GOV.UK Signon email address is being changed", email_changed_notification.subject
         assert_equal "old@email.com", email_changed_notification.to.first
       end
 

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -84,7 +84,7 @@ class UsersControllerTest < ActionController::TestCase
         assert_equal "new@email.com", confirmation_email.to.first
 
         email_changed_notification = ActionMailer::Base.deliveries.last
-        assert_equal "Your email is being changed", email_changed_notification.subject
+        assert_equal "Your GOV.UK Signon email is being changed", email_changed_notification.subject
         assert_equal "old@email.com", email_changed_notification.to.first
       end
 

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -72,16 +72,20 @@ class UsersControllerTest < ActionController::TestCase
     end
 
     context "changing an email" do
-      should "stage the change, and send a confirmation email" do
+      should "stage the change, send a confirmation email to the new address and email change notification to the old address" do
         put :update, user: { email: "new@email.com" }
 
         @user.reload
         assert_equal "new@email.com", @user.unconfirmed_email
         assert_equal "old@email.com", @user.email
 
-        email = ActionMailer::Base.deliveries.last
-        assert_equal "Confirm your email change", email.subject
-        assert_equal "new@email.com", email.to[0]
+        confirmation_email = ActionMailer::Base.deliveries[-2]
+        assert_equal "Confirm your email change", confirmation_email.subject
+        assert_equal "new@email.com", confirmation_email.to.first
+
+        email_changed_notification = ActionMailer::Base.deliveries.last
+        assert_equal "Your email is being changed", email_changed_notification.subject
+        assert_equal "old@email.com", email_changed_notification.to.first
       end
 
       should "log an event" do

--- a/test/integration/email_change_test.rb
+++ b/test/integration/email_change_test.rb
@@ -19,7 +19,7 @@ class EmailChangeTest < ActionDispatch::IntegrationTest
           admin_changes_email_address(user: user, new_email: "new@email.com")
 
           assert_equal "new@email.com", last_email.to[0]
-          assert_equal 'Your GOV.UK Signon email has been updated', last_email.subject
+          assert_equal 'Your GOV.UK Signon email address has been updated', last_email.subject
         end
       end
 
@@ -107,7 +107,7 @@ class EmailChangeTest < ActionDispatch::IntegrationTest
       assert_equal "new@email.com", confirmation_email.to.first
       assert_equal 'Confirm your email change', confirmation_email.subject
       assert_equal "original@email.com", notification_email.to.first
-      assert_equal 'Your GOV.UK Signon email is being changed', notification_email.subject
+      assert_equal 'Your GOV.UK Signon email address is being changed', notification_email.subject
     end
 
     should "log email change events in the user's event log" do

--- a/test/integration/email_change_test.rb
+++ b/test/integration/email_change_test.rb
@@ -19,7 +19,7 @@ class EmailChangeTest < ActionDispatch::IntegrationTest
           admin_changes_email_address(user: user, new_email: "new@email.com")
 
           assert_equal "new@email.com", last_email.to[0]
-          assert_equal 'Your email has been updated', last_email.subject
+          assert_equal 'Your GOV.UK Signon email has been updated', last_email.subject
         end
       end
 
@@ -107,7 +107,7 @@ class EmailChangeTest < ActionDispatch::IntegrationTest
       assert_equal "new@email.com", confirmation_email.to.first
       assert_equal 'Confirm your email change', confirmation_email.subject
       assert_equal "original@email.com", notification_email.to.first
-      assert_equal 'Your email is being changed', notification_email.subject
+      assert_equal 'Your GOV.UK Signon email is being changed', notification_email.subject
     end
 
     should "log email change events in the user's event log" do

--- a/test/integration/email_change_test.rb
+++ b/test/integration/email_change_test.rb
@@ -95,7 +95,7 @@ class EmailChangeTest < ActionDispatch::IntegrationTest
       @user = create(:user, email: "original@email.com")
     end
 
-    should "trigger a confirmation email to the user" do
+    should "trigger a confirmation email to the user's new address and a notification to the user's old address" do
       visit new_user_session_path
       signin(@user)
 
@@ -103,8 +103,11 @@ class EmailChangeTest < ActionDispatch::IntegrationTest
       fill_in "Email", with: "new@email.com"
       click_button "Change email"
 
-      assert_equal "new@email.com", last_email.to[0]
-      assert_equal 'Confirm your email change', last_email.subject
+      confirmation_email, notification_email = *ActionMailer::Base.deliveries[-2..-1]
+      assert_equal "new@email.com", confirmation_email.to.first
+      assert_equal 'Confirm your email change', confirmation_email.subject
+      assert_equal "original@email.com", notification_email.to.first
+      assert_equal 'Your email is being changed', notification_email.subject
     end
 
     should "log email change events in the user's event log" do


### PR DESCRIPTION
following-up on these changes: https://github.com/alphagov/signonotron2/pull/302

When a user updates their own email address:

1. they should be sent a confirmation email at their new email address (exisiting behaviour), and
2. they should be notified about that change being initiated at their old emails address (new).

There's no corresponding story for this change, is an outcome of discussions in Slack.

/cc: @fofr, @marksheldonGDS 