### PR TITLE
Reword the passphrase reset "email sent" flash message

### DIFF
--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -30,7 +30,7 @@ en:
       send_instructions: 'You will receive an email with instructions about how to reset your passphrase in a few minutes.'
       updated: 'Your passphrase was changed successfully.'
       updated_not_active: 'Your passphrase was changed successfully.'
-      send_paranoid_instructions: "If your email exists on our database, you will receive a passphrase recovery link on your email"
+      send_paranoid_instructions: "If your email address is recognised, you’ll receive an email with instructions about how to reset your passphrase."
       new:
         send_passphrase_reset: "Send me passphrase reset instructions"
     confirmations:

--- a/test/integration/passphrase_reset_test.rb
+++ b/test/integration/passphrase_reset_test.rb
@@ -4,7 +4,7 @@ require 'helpers/passphrase_support'
 class PassphraseResetTest < ActionDispatch::IntegrationTest
   include PassPhraseSupport
 
-  BLANKET_RESET_MESSAGE = "If your email exists on our database, you will receive a passphrase recovery link on your email"
+  BLANKET_RESET_MESSAGE = "If your email address is recognised, you’ll receive an email with instructions about how to reset your passphrase."
 
   should "reset a user's password and let them set a new one" do
     user = create(:user)


### PR DESCRIPTION
- I reset my passphrase earlier and thought that the wording was a bit weird.
  With Paul's help, here's an attempt at changing it.