### PR TITLE
Allow adding a note to a user when editing.

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -60,6 +60,10 @@ class UsersController < ApplicationController
           end
         end
 
+        if params[:note] && (params[:note][:details].present? || params[:note][:occurred_on].present?)
+          @user.notes << Note.new(params[:note])
+        end
+
         redirect_to users_path, notice: "Updated user #{@user.email} successfully"
       else
         render :edit

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,0 +1,11 @@
+class Note < ActiveRecord::Base
+  self.inheritance_column = nil
+
+  TYPES = {
+    training: "Training",
+    permission_granted: "Permission granted",
+    permission_removed: "Permission removed",
+    disciplinary_action: "Disciplinary action",
+    other: "Other event"
+  }.freeze
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,6 +35,7 @@ class User < ActiveRecord::Base
   validate :email_is_ascii_only
 
   has_many :authorisations, :class_name => 'Doorkeeper::AccessToken', :foreign_key => :resource_owner_id
+  has_many :notes
   has_many :permissions, inverse_of: :user
   has_many :batch_invitations
   has_many :event_logs, primary_key: :uid, foreign_key: :uid, order: 'created_at DESC'

--- a/app/views/users/_form_fields.html.erb
+++ b/app/views/users/_form_fields.html.erb
@@ -46,3 +46,23 @@
 <h2 class="add-vertical-margins">Permissions</h2>
 
 <%= render partial: "shared/user_permissions", locals: { user_object: f.object }%>
+
+<h2>Add a note (optional)</h2>
+<fieldset class="new-note">
+  <%= fields_for :note, Note.new do |note_form| %>
+    <p class="form-group">
+      <label for="note_type">Type</label><br />
+      <%= note_form.select :type, options_for_select(Note::TYPES.invert), {}, class: "chosen-select form-control", 'data-module' => 'chosen' %>
+    </p>
+
+    <p class="form-group">
+      <label for="note_occurred_on">Occurred on</label><br />
+      <%= note_form.text_field :occurred_on, class: "form-control input-md-6", placeholder: "eg 2014-11-22" %>
+    </p>
+
+    <p class="form-group">
+      <label for="note_details">Details</label>
+      <%= note_form.text_field :details, class: "form-control input-md-6" %>
+    </p>
+  <% end %>
+</fieldset>

--- a/db/migrate/20150121111004_create_note.rb
+++ b/db/migrate/20150121111004_create_note.rb
@@ -1,0 +1,14 @@
+class CreateNote < ActiveRecord::Migration
+  def up
+    create_table :notes do |t|
+      t.references :user
+      t.string :type
+      t.string :details
+      t.date :occurred_on
+    end
+  end
+
+  def down
+    remove_table :notes
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150107063935) do
+ActiveRecord::Schema.define(:version => 20150121111004) do
 
   create_table "batch_invitation_users", :force => true do |t|
     t.integer  "batch_invitation_id"
@@ -45,6 +45,13 @@ ActiveRecord::Schema.define(:version => 20150107063935) do
   end
 
   add_index "event_logs", ["uid", "created_at"], :name => "index_event_logs_on_uid_and_created_at"
+
+  create_table "notes", :force => true do |t|
+    t.integer "user_id"
+    t.string  "type"
+    t.string  "details"
+    t.date    "occurred_on"
+  end
 
   create_table "oauth_access_grants", :force => true do |t|
     t.integer  "resource_owner_id", :null => false

--- a/test/integration/granting_permissions_test.rb
+++ b/test/integration/granting_permissions_test.rb
@@ -30,4 +30,26 @@ class GrantingPermissionsTest < ActionDispatch::IntegrationTest
     permission = Permission.where(application_id: app.id, user_id: @user.id).first
     assert_equal ["write"], permission.permissions
   end
+
+  should "allow the admin to note key events for that user, such as training" do
+    app = create(:application, name: "MyApp", with_supported_permissions: ["write"])
+
+    visit edit_user_path(@user)
+    select "write", from: "Permissions for MyApp"
+
+    within ".new-note" do
+      fill_in "Details", with: "Completed author training"
+      select "Training", from: "Type"
+      fill_in "Occurred on", with: "2014-11-22"
+    end
+
+    click_button "Update User"
+
+    assert_equal 1, @user.notes.count
+
+    last_note = @user.notes.last
+    assert_equal "Completed author training", last_note.details
+    assert_equal "training", last_note.type
+    assert_equal "2014-11-22", last_note.occurred_on.strftime("%F")
+  end
 end


### PR DESCRIPTION
DO NOT MERGE BEFORE https://github.com/alphagov/signonotron2/pull/298

Allows tracking of training, reasons for granting
or revoking specific permissions etc.

Requested by GOV.UK content team.

- [x] Data input
- [ ] Data output

![screenshot 2015-01-21 13 05 55](https://cloud.githubusercontent.com/assets/109225/5836478/44fc961e-a16e-11e4-9f60-b38a823bb7b2.png)