### PR TITLE
Fix password reset flow

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ gem 'logstasher', '0.4.8'
 
 group :test do
   gem 'capybara', '2.2.1'
+  gem 'capybara-email', '~> 2.3.0'
   gem 'poltergeist', '1.5.0'
   gem 'database_cleaner', '0.7.2'
   gem 'factory_girl_rails', '4.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,9 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    capybara-email (2.3.0)
+      capybara (~> 2.2.0)
+      mail
     celluloid (0.15.2)
       timers (~> 1.1.0)
     chronic (0.10.2)
@@ -258,6 +261,7 @@ DEPENDENCIES
   bootstrap-kaminari-views (= 0.0.5)
   cancan (= 1.6.10)
   capybara (= 2.2.1)
+  capybara-email (~> 2.3.0)
   ci_reporter (= 1.7.0)
   database_cleaner (= 0.7.2)
   devise (= 2.2.5)

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -6,11 +6,6 @@ class PasswordsController < Devise::PasswordsController
     unless self.resource && self.resource.reset_password_period_valid?
       render 'devise/passwords/reset_error' and return
     end
-
-    # Unfortunately (and surprisingly) the model method to change the reset password
-    # token is protected. It seems better to break that protection than to reimplement
-    # the same feature ourselves.
-    self.resource.__send__(:generate_reset_password_token!)
   end
 
   # overrides http://git.io/sOhoaA to prevent expirable from

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -28,7 +28,7 @@ Signonotron2::Application.configure do
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
-  config.action_mailer.default_url_options = { :host => 'localhost:3000' }
+  config.action_mailer.default_url_options = { :host => 'www.example.com' }
 
   # Raise exception on mass assignment protection for Active Record models
   # config.active_record.mass_assignment_sanitizer = :strict

--- a/test/helpers/email_helpers.rb
+++ b/test/helpers/email_helpers.rb
@@ -1,5 +1,9 @@
+require 'capybara/email'
+
 module EmailHelpers
+  include Capybara::Email::DSL
+
   def last_email
-    ActionMailer::Base.deliveries.last
+    all_emails.last
   end
 end

--- a/test/helpers/passphrase_support.rb
+++ b/test/helpers/passphrase_support.rb
@@ -22,8 +22,8 @@ module PassPhraseSupport
     click_button "Send me passphrase reset instructions"
   end
 
-  def complete_password_reset(options)
-    visit edit_user_password_path(reset_password_token: options[:reset_password_token])
+  def complete_password_reset(email, options)
+    email.click_link("Change my passphrase")
     fill_in "New passphrase", with: options[:new_password]
     fill_in "Confirm new passphrase", with: options[:new_password]
     click_button "Change my passphrase"

--- a/test/integration/batch_inviting_users_test.rb
+++ b/test/integration/batch_inviting_users_test.rb
@@ -1,8 +1,7 @@
 require 'test_helper'
 require 'sidekiq/testing'
- 
+
 class BatchInvitingUsersTest < ActionDispatch::IntegrationTest
-  include EmailHelpers
 
   should "create users whose details are specified in a CSV file" do
     Sidekiq::Testing.inline! do

--- a/test/integration/passphrase_reset_test.rb
+++ b/test/integration/passphrase_reset_test.rb
@@ -1,24 +1,29 @@
 require 'test_helper'
 require 'helpers/passphrase_support'
- 
+
 class PassphraseResetTest < ActionDispatch::IntegrationTest
   include PassPhraseSupport
 
   BLANKET_RESET_MESSAGE = "If your email address is recognised, you’ll receive an email with instructions about how to reset your passphrase."
 
-  should "reset a user's password and let them set a new one" do
-    user = create(:user)
-    new_password = "some v3ry s3cure passphrase"
+  should "email password reset instructions and allow the user to set a new one" do
+    Sidekiq::Testing.inline! do
+      user = create(:user)
+      new_password = "some v3ry s3cure passphrase"
 
-    trigger_reset_for(user.email)
-    assert_response_contains(BLANKET_RESET_MESSAGE)
-    
-    user.reload
-    complete_password_reset(reset_password_token: user.reset_password_token, new_password: new_password)
+      trigger_reset_for(user.email)
+      assert_response_contains(BLANKET_RESET_MESSAGE)
 
-    assert_response_contains("Your passphrase was changed successfully")
-    user.reload
-    assert user.valid_password?(new_password)
+      open_email(user.email)
+      assert current_email
+      assert_equal "Reset passphrase instructions", current_email.subject
+
+      complete_password_reset(current_email, new_password: new_password)
+      assert_response_contains("Your passphrase was changed successfully")
+
+      user.reload
+      assert user.valid_password?(new_password)
+    end
   end
 
   should "not give away whether an email exists in the system or not" do
@@ -39,16 +44,44 @@ class PassphraseResetTest < ActionDispatch::IntegrationTest
   end
 
   should "work for a partially signed-in user with an expired passphrase" do
-    user = create(:user, password_changed_at: 3.months.ago)
+    Sidekiq::Testing.inline! do
+      user = create(:user, password_changed_at: 3.months.ago)
 
-    trigger_reset_for(user.email)
+      trigger_reset_for(user.email)
 
-    visit root_path
-    signin(email: user.email, password: user.password)
+      visit root_path
+      signin(email: user.email, password: user.password)
 
-    # partially signed-in user should be able to reset passphrase using link in reset passphrase instructions
-    complete_password_reset(reset_password_token: user.reload.reset_password_token, new_password: "some v3ry s3cure passphrase")
-    assert_response_contains("Your passphrase was changed successfully")
+      open_email(user.email)
+      assert current_email
+      assert_equal "Reset passphrase instructions", current_email.subject
+
+      # partially signed-in user should be able to reset passphrase using link in reset passphrase instructions
+      complete_password_reset(current_email, new_password: "some v3ry s3cure passphrase")
+      assert_response_contains("Your passphrase was changed successfully")
+    end
+  end
+
+  should "not allow a reset link to be used more than once" do
+    Sidekiq::Testing.inline! do
+      user = create(:user)
+      new_password = "some v3ry s3cure passphrase"
+
+      trigger_reset_for(user.email)
+
+      open_email(user.email)
+      assert current_email
+      assert_equal "Reset passphrase instructions", current_email.subject
+
+      complete_password_reset(current_email, new_password: new_password)
+      assert_response_contains("Your passphrase was changed successfully")
+
+      signout
+
+      current_email.click_link("Change my passphrase")
+
+      assert_response_contains("That passphrase reset didn’t work.")
+    end
   end
 
   should "be accessible from the change password screen by a partially signed-in user" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -107,6 +107,6 @@ class ActionDispatch::IntegrationTest
     Capybara.use_default_driver
 
     ActionController::Base.allow_forgery_protection = @original_forgery_protection_value
-    ActionMailer::Base.deliveries.clear
+    clear_emails
   end
 end


### PR DESCRIPTION
This partially reverts a044b79 (PR #65).

It would seem that some of our users have virus-scanning systems that
follow links in emails to check for anything malicious.  This was
breaking the passphrase reset flow because the token was being reset the
first time the page was accessed.  The root of this problem is that we
have a GET route in the application that has side-effects.

This removes this functionality so that a password reset token will
continue to work until the passphrase has been reset, at which point
it's cleared (this is standard devise behaviour).

Note: This branch has been based on `release_498` so that it can be deployed as a hotfix without having to deploy #298 at the same time.