### PR TITLE
Make the user's name a link to edit themselves

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,4 +12,13 @@ module ApplicationHelper
       end
     end
   end
+
+  def user_link_target
+    # The page the current user's name in the header should link them to
+    if policy(current_user).edit?
+      edit_user_path(current_user)
+    else
+      root_path
+    end
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,7 +27,7 @@
 
 <% if user_signed_in? && params[:controller] !~ %r{doorkeeper/} %>
   <% content_for :navbar_right do %>
-    <%= link_to current_user.name, root_path %>
+    <%= link_to current_user.name, user_link_target %>
     &bull; <%= link_to 'Sign out', destroy_user_session_path %>
   <% end %>
 <% end %>

--- a/test/integration/user_link_test.rb
+++ b/test/integration/user_link_test.rb
@@ -1,0 +1,16 @@
+require_relative "../test_helper"
+
+class UserLinkTest < ActionDispatch::IntegrationTest
+  context "logged in as an admin" do
+    setup do
+      @admin = create(:admin_user, :name => "Adam Adminson", :email => "admin@example.com")
+      visit new_user_session_path
+      signin(@admin)
+    end
+
+    should "link to the current user's edit page" do
+      click_on "Adam Adminson"
+      assert page.has_content?('Edit “Adam Adminson”')
+    end
+  end
+end


### PR DESCRIPTION
![signon-quick-link](https://cloud.githubusercontent.com/assets/32775/5855778/ce92902a-a233-11e4-9bba-09d5f6b82207.gif)

It's quite a common use case, at least for GOV.UK developers, to want to change their own permissions to test some permission-based feature in an app, which involves going to the user section and searching for their user record. If they have to do this multiple times, it's tedious and introduces the risk that they'll change permissions for someone else by mistake.

The original destination for this link was to the Signon root page: this is consistent with other apps, where it makes sense to link through to Signon; when you're in Signon already, this isn't particularly useful, especially when the "GOV.UK Signon" link in the header takes you there already.

The logic to determine the link target depends on whether the user has permission to edit themselves. As the logic currently stands, every user in the system has permission to edit themselves to at least some extent, but we shouldn't assume this will always be the case.