### PR TITLE
Add resend? to UserPolicy

### DIFF
--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -26,6 +26,7 @@ class UserPolicy < BasePolicy
   alias_method :update_passphrase?, :edit?
   alias_method :cancel_email_change?, :edit?
   alias_method :resend_email_change?, :edit?
+  alias_method :resend?, :edit?
 
   def event_logs?
     current_user.normal? ? false : edit?

--- a/test/functional/invitations_controller_test.rb
+++ b/test/functional/invitations_controller_test.rb
@@ -95,4 +95,16 @@ class InvitationsControllerTest < ActionController::TestCase
       end
     end
   end
+
+  context "POST resend" do
+    should "resend account signup email to user" do
+      admin, user = create(:admin_user), create(:user)
+      User.any_instance.expects(:invite!).once
+      sign_in admin
+
+      post :resend, id: user.id
+
+      assert_redirected_to users_path
+    end
+  end
 end


### PR DESCRIPTION
when an admin tries to resend an invitation, the page blows-up because there is no policy defined for that action.

fixes: [errbit](https://errbit.preview.alphagov.co.uk/apps/52e678360da1158195000002/problems/54c6800e0da1159ab2008c60)