### PR TITLE
Fix CSV export to work with remodelled permissions.

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -129,7 +129,6 @@ class UsersController < ApplicationController
   end
 
   def filter_users
-    @users = @users.includes(:permissions) if should_include_permissions?
     @users = @users.filter(params[:filter]) if params[:filter].present?
     @users = @users.with_role(params[:role]) if can_filter_role?
     @users = @users.with_organisation(params[:organisation]) if params[:organisation].present?

--- a/app/presenters/user_export_presenter.rb
+++ b/app/presenters/user_export_presenter.rb
@@ -34,8 +34,8 @@ class UserExportPresenter
 
   def app_permissions
     applications.map do |application|
-      perm = user.permissions.detect { |p| p.application_id == application.id }
-      perm.permissions.sort.join(', ') if perm
+      perms = user.permissions_for(application)
+      perms.sort.join(', ') if perms.any?
     end
   end
 end

--- a/test/unit/user_export_presenter_test.rb
+++ b/test/unit/user_export_presenter_test.rb
@@ -5,6 +5,9 @@ class UserExportPresenterTest < ActiveSupport::TestCase
     Timecop.freeze(2015, 1, 15, 9, 0)
     @apps = 5.times.map {|i| create(:application, name: "App #{i}") }
     @user = create(:user, name: "Test User", email: "test@dept.gov.uk")
+    create(:supported_permission, application: @apps[0], name: "editor")
+    create(:supported_permission, application: @apps[2], name: "editor")
+    create(:supported_permission, application: @apps[2], name: "admin")
   end
 
 
@@ -19,8 +22,8 @@ class UserExportPresenterTest < ActiveSupport::TestCase
   end
 
   should "include sorted permissions for each application" do
-    create(:permission, user: @user, application: @apps[0], permissions: ["editor"])
-    create(:permission, user: @user, application: @apps[2], permissions: ["editor", "admin"])
+    @user.grant_application_permissions(@apps[0], ["editor"])
+    @user.grant_application_permissions(@apps[2], ["editor", "admin"])
 
     perms = UserExportPresenter.new(@user, @apps).app_permissions
 


### PR DESCRIPTION
The remodelled permissions branch didn't include this feature due to
them being created in parallel, so when it was merged, things broke.