### PR TITLE
Upgrade doorkeeper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'devise_zxcvbn', '1.1.1'
 gem 'devise-async', '0.8.0'
 gem 'pundit', '0.3.0'
 
-gem 'doorkeeper', '0.6.7'
+gem 'doorkeeper', '2.1.0'
 gem 'ancestry', '2.0.0'
 
 gem 'gds-api-adapters', '7.11.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,8 +89,8 @@ GEM
       devise
       zxcvbn-ruby (>= 0.0.2)
     diff-lcs (1.2.5)
-    doorkeeper (0.6.7)
-      railties (~> 3.1)
+    doorkeeper (2.1.0)
+      railties (>= 3.1)
     erubis (2.7.0)
     factory_girl (4.3.0)
       activesupport (>= 3.0.0)
@@ -287,7 +287,7 @@ DEPENDENCIES
   devise_invitable (= 1.1.5)
   devise_security_extension (= 0.7.2)!
   devise_zxcvbn (= 1.1.1)
-  doorkeeper (= 0.6.7)
+  doorkeeper (= 2.1.0)
   factory_girl_rails (= 4.3.0)
   gds-api-adapters (= 7.11.0)
   govuk_admin_template (= 1.4.2)

--- a/README.md
+++ b/README.md
@@ -134,14 +134,13 @@ end
 
 To require Doorkeeper authentication in a controller (i.e., you want an
 application that has been granted a token on behalf of a user to interact with
-the controller), add `doorkeeper_for :all` or `doorkeeper_for :action` to the
-controller.
+the controller), add `before_filter :doorkeeper_authorize!` to the controller.
 
 For example:
 
 ```ruby
 class AutomaticApiController
-  doorkeeper_for :swizzle
+  before_filter :doorkeeper_authorize!
 
   def swizzle
     @token_owning_user = User.find_by_id(doorkeeper_token.resource_owner_id)

--- a/app/controllers/doorkeeper_applications_controller.rb
+++ b/app/controllers/doorkeeper_applications_controller.rb
@@ -1,4 +1,4 @@
-class ApplicationsController < ApplicationController
+class DoorkeeperApplicationsController < ApplicationController
   before_filter :authenticate_user!
   before_filter :load_and_authorize_application, except: :index
 
@@ -10,8 +10,8 @@ class ApplicationsController < ApplicationController
   end
 
   def update
-    if @application.update_attributes(params[:application])
-      redirect_to applications_path, notice: "Successfully updated #{@application.name}"
+    if @application.update_attributes(params[:doorkeeper_application])
+      redirect_to doorkeeper_applications_path, notice: "Successfully updated #{@application.name}"
     else
       respond_with @application
     end

--- a/app/controllers/supported_permissions_controller.rb
+++ b/app/controllers/supported_permissions_controller.rb
@@ -14,7 +14,7 @@ class SupportedPermissionsController < ApplicationController
   def create
     @supported_permission = @application.supported_permissions.build(supported_permission_parameters)
     if @supported_permission.save
-      redirect_to application_supported_permissions_path,
+      redirect_to doorkeeper_application_supported_permissions_path,
         notice: "Successfully added permission #{@supported_permission.name} to #{@application.name}"
     else
       render :new
@@ -24,7 +24,7 @@ class SupportedPermissionsController < ApplicationController
   def update
     @supported_permission = SupportedPermission.find(params[:id])
     if @supported_permission.update_attributes(supported_permission_parameters)
-      redirect_to application_supported_permissions_path,
+      redirect_to doorkeeper_application_supported_permissions_path,
         notice: "Successfully updated permission #{@supported_permission.name}"
     else
       render :edit
@@ -34,7 +34,7 @@ class SupportedPermissionsController < ApplicationController
 private
 
   def load_and_authorize_application
-    @application = Doorkeeper::Application.find(params[:application_id])
+    @application = Doorkeeper::Application.find(params[:doorkeeper_application_id])
     authorize @application, :manage_supported_permissions?
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,7 @@ class UsersController < ApplicationController
   helper_method :applications_and_permissions, :any_filter?
   respond_to :html
 
-  doorkeeper_for :show
+  before_filter :doorkeeper_authorize!, only: :show
   before_filter :validate_token_matches_client_id, :only => :show
   skip_after_filter :verify_authorized, only: :show
 

--- a/app/models/enhancements/application.rb
+++ b/app/models/enhancements/application.rb
@@ -18,6 +18,8 @@ class ::Doorkeeper::Application < ActiveRecord::Base
 
   after_create :create_signin_supported_permission
 
+  def self.policy_class; ApplicationPolicy; end
+
   def supported_permission_strings(user=nil)
     if user && user.role == 'organisation_admin'
       supported_permissions.delegatable.pluck(:name) & user.permissions_for(self)

--- a/app/models/enhancements/application.rb
+++ b/app/models/enhancements/application.rb
@@ -1,8 +1,9 @@
-require "doorkeeper/models/application"
+require "doorkeeper/orm/active_record/application"
 
 class ::Doorkeeper::Application < ActiveRecord::Base
   has_many :permissions, :dependent => :destroy
   has_many :supported_permissions, :dependent => :destroy
+
 
   attr_accessible :name, :description, :uid, :secret, :redirect_uri, :home_uri
   attr_accessible :supports_push_updates, role: :superadmin

--- a/app/views/doorkeeper_applications/edit.html.erb
+++ b/app/views/doorkeeper_applications/edit.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, "Edit application" %>
 
 <ol class="breadcrumb">
-  <li><%= link_to 'Applications', applications_path %></li>
+  <li><%= link_to 'Applications', doorkeeper_applications_path %></li>
   <li class="active"><%= @application.name %></li>
 </ol>
 
@@ -66,7 +66,7 @@
   <% if policy(Doorkeeper::Application).edit? %>
     <hr />
     <p class="add-top-margin">
-      <%= link_to "Edit supported permissions", application_supported_permissions_path(@application) %>
+      <%= link_to "Edit supported permissions", doorkeeper_application_supported_permissions_path(@application) %>
     </p>
     <hr />
   <% end %>

--- a/app/views/doorkeeper_applications/index.html.erb
+++ b/app/views/doorkeeper_applications/index.html.erb
@@ -15,13 +15,13 @@
     <% @applications.each do |application| %>
       <tr>
         <td>
-          <%= link_to application.name, edit_application_path(application) %>
+          <%= link_to application.name, edit_doorkeeper_application_path(application) %>
           <br>
           <%= application.description %>
         </td>
         <td><%= application.redirect_uri %></td>
         <td><%= link_to application.home_uri, application.home_uri %></td>
-        <td><%= link_to "Edit", edit_application_path(application) %></td>
+        <td><%= link_to "Edit", edit_doorkeeper_application_path(application) %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,7 +17,7 @@
       <%= nav_link 'API Users', api_users_path %>
     <% end %>
     <% if policy(Doorkeeper::Application).index? %>
-      <%= nav_link 'Applications', applications_path %>
+      <%= nav_link 'Applications', doorkeeper_applications_path %>
     <% end %>
     <% if policy(Organisation).index? %>
       <%= nav_link 'Organisations', organisations_path %>

--- a/app/views/supported_permissions/edit.html.erb
+++ b/app/views/supported_permissions/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, "Edit permission" %>
 
 <ol class="breadcrumb">
-  <li><%= link_to 'Applications', applications_path %></li>
-  <li><%= link_to @application.name, edit_application_path(@application) %></li>
-  <li><%= link_to 'Permissions', application_supported_permissions_path(@application) %></li>
+  <li><%= link_to 'Applications', doorkeeper_applications_path %></li>
+  <li><%= link_to @application.name, edit_doorkeeper_application_path(@application) %></li>
+  <li><%= link_to 'Permissions', doorkeeper_application_supported_permissions_path(@application) %></li>
   <li class="active">Edit permission</li>
 </ol>
 

--- a/app/views/supported_permissions/index.html.erb
+++ b/app/views/supported_permissions/index.html.erb
@@ -1,8 +1,8 @@
 <% content_for :title, "Permissions for #{@application.name}" %>
 
 <ol class="breadcrumb">
-  <li><%= link_to 'Applications', applications_path %></li>
-  <li><%= link_to @application.name, edit_application_path(@application) %></li>
+  <li><%= link_to 'Applications', doorkeeper_applications_path %></li>
+  <li><%= link_to @application.name, edit_doorkeeper_application_path(@application) %></li>
   <li class="active">Permissions</li>
 </ol>
 
@@ -10,7 +10,7 @@
   <h1>Permissions for “<%= @application.name %>”</h1>
 </div>
 
-<%= link_to new_application_supported_permission_path, id: "add", class: "btn btn-success" do %>
+<%= link_to new_doorkeeper_application_supported_permission_path, id: "add", class: "btn btn-success" do %>
   <span class="glyphicon glyphicon-plus"></span> Add permission
 <% end %>
 
@@ -35,7 +35,7 @@
     <% @application.sorted_supported_permissions.each do |supported_permission| %>
       <tr>
         <td class="name">
-          <%= link_to supported_permission.name, edit_application_supported_permission_path(@application, supported_permission) %>
+          <%= link_to supported_permission.name, edit_doorkeeper_application_supported_permission_path(@application, supported_permission) %>
         </td>
         <td>
           <%= supported_permission.created_at.to_date.to_s(:govuk_date) %>
@@ -44,7 +44,7 @@
           <%= supported_permission.delegatable? ? 'Yes' : 'No' %>
         </td>
         <td>
-          <%= link_to 'Edit', edit_application_supported_permission_path(@application, supported_permission) %>
+          <%= link_to 'Edit', edit_doorkeeper_application_supported_permission_path(@application, supported_permission) %>
         </td>
       </tr>
     <% end %>

--- a/app/views/supported_permissions/new.html.erb
+++ b/app/views/supported_permissions/new.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, "Single Signon application permissions" %>
 
 <ol class="breadcrumb">
-  <li><%= link_to 'Applications', applications_path %></li>
-  <li><%= link_to @application.name, edit_application_path(@application) %></li>
-  <li><%= link_to 'Permissions', application_supported_permissions_path(@application) %></li>
+  <li><%= link_to 'Applications', doorkeeper_applications_path %></li>
+  <li><%= link_to @application.name, edit_doorkeeper_application_path(@application) %></li>
+  <li><%= link_to 'Permissions', doorkeeper_application_supported_permissions_path(@application) %></li>
   <li class="active">Add permission</li>
 </ol>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,7 @@ Signonotron2::Application.routes.draw do
   resources :organisations, only: [:index]
   resources :suspensions, only: [:edit, :update]
 
-  resources :applications, only: [:index, :edit, :update] do
+  resources :doorkeeper_applications, only: [:index, :edit, :update] do
     resources :supported_permissions, only: [:index, :new, :create, :edit, :update]
   end
 

--- a/test/functional/doorkeeper_applications_controller_test.rb
+++ b/test/functional/doorkeeper_applications_controller_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class ApplicationsControllerTest < ActionController::TestCase
+class DoorkeeperApplicationsControllerTest < ActionController::TestCase
 
   setup do
     @user = create(:user, role: "superadmin")
@@ -19,24 +19,24 @@ class ApplicationsControllerTest < ActionController::TestCase
     should "render the form" do
       app = create(:application, name: "My first app")
       get :edit, id: app.id
-      assert_select "input[name='application[name]'][value='My first app']"
+      assert_select "input[name='doorkeeper_application[name]'][value='My first app']"
     end
   end
 
   context "PUT update" do
     should "update the application" do
       app = create(:application, name: "My first app")
-      put :update, id: app.id, application: { name: "A better name" }
+      put :update, id: app.id, doorkeeper_application: { name: "A better name" }
 
       assert_equal "A better name", app.reload.name
-      assert_redirected_to applications_path
+      assert_redirected_to doorkeeper_applications_path
       assert_match(/updated/, flash[:notice])
     end
 
     should "redisplay the form if save fails" do
       app = create(:application, name: "My first app")
-      put :update, id: app.id, application: { name: "" }
-      assert_select "form#edit_application_#{app.id}"
+      put :update, id: app.id, doorkeeper_application: { name: "" }
+      assert_select "form#edit_doorkeeper_application_#{app.id}"
     end
   end
 end

--- a/test/functional/supported_permissions_controller_test.rb
+++ b/test/functional/supported_permissions_controller_test.rb
@@ -11,7 +11,7 @@ class SupportedPermissionsControllerTest < ActionController::TestCase
     should "render the permissions list" do
       app = create(:application, name: "My first app", with_delegatable_supported_permissions: ["permission1"])
 
-      get :index, application_id: app.id
+      get :index, doorkeeper_application_id: app.id
 
       assert_select "h1", /My first app/
       assert_select "td[class=name]", /permission1/
@@ -23,7 +23,7 @@ class SupportedPermissionsControllerTest < ActionController::TestCase
   context "GET new" do
     should "render the form" do
       app = create(:application, name: "My first app", with_supported_permissions: ["permission1"])
-      get :new, application_id: app.id
+      get :new, doorkeeper_application_id: app.id
       assert_select "h1", /Add permission/
       assert_select ".breadcrumb li", /My first app/
       assert_select "input[name='supported_permission[name]']", true
@@ -34,7 +34,7 @@ class SupportedPermissionsControllerTest < ActionController::TestCase
     should "show error if name is not provided and not create a permission" do
       app = create(:application, name: "My first app")
 
-      post :create, application_id: app.id, supported_permission: { name: "" }
+      post :create, doorkeeper_application_id: app.id, supported_permission: { name: "" }
 
       assert_select "ul[class='errors'] li", ERB::Util.html_escape("Name can't be blank")
       assert_equal app.reload.supported_permissions, [app.signin_permission]
@@ -43,7 +43,7 @@ class SupportedPermissionsControllerTest < ActionController::TestCase
     should "create a new permission" do
       app = create(:application, name: "My first app")
 
-      post :create, application_id: app.id, supported_permission: { name: "permission1" }
+      post :create, doorkeeper_application_id: app.id, supported_permission: { name: "permission1" }
 
       assert_redirected_to(:controller => "supported_permissions", :action => :index)
       assert_equal "Successfully added permission permission1 to My first app", flash[:notice]
@@ -57,7 +57,7 @@ class SupportedPermissionsControllerTest < ActionController::TestCase
       perm = create(:supported_permission, application_id: app.id,
                                   name: "permission1", delegatable: true, created_at: 2.days.ago)
 
-      put :update, application_id: app.id, id: perm.id, supported_permission: { name: "", delegatable: false }
+      put :update, doorkeeper_application_id: app.id, id: perm.id, supported_permission: { name: "", delegatable: false }
 
       assert_select "ul[class='errors'] li", ERB::Util.html_escape("Name can't be blank")
       assert_true perm.reload.delegatable
@@ -68,7 +68,7 @@ class SupportedPermissionsControllerTest < ActionController::TestCase
       perm = create(:supported_permission, application_id: app.id,
                                   name: "permission1", delegatable: true, created_at: 2.days.ago)
 
-      put :update, application_id: app.id, id: perm.id, supported_permission: { delegatable: false }
+      put :update, doorkeeper_application_id: app.id, id: perm.id, supported_permission: { delegatable: false }
 
       assert_redirected_to(:controller => "supported_permissions", :action => :index)
       assert_equal "Successfully updated permission permission1", flash[:notice]

--- a/test/unit/sso_push_client_test.rb
+++ b/test/unit/sso_push_client_test.rb
@@ -3,12 +3,12 @@ require 'test_helper'
 class SSOPushClientTest < ActiveSupport::TestCase
   def reauth_url(application)
     url = URI.parse(application.redirect_uri)
-    "http://#{url.host}/auth/gds/api/users/#{CGI.escape(@user.uid)}/reauth"
+    "https://#{url.host}/auth/gds/api/users/#{CGI.escape(@user.uid)}/reauth"
   end
 
   def users_url(application)
     url = URI.parse(application.redirect_uri)
-    "http://#{url.host}/auth/gds/api/users/#{CGI.escape(@user.uid)}"
+    "https://#{url.host}/auth/gds/api/users/#{CGI.escape(@user.uid)}"
   end
 
   context "update_user" do
@@ -17,7 +17,7 @@ class SSOPushClientTest < ActiveSupport::TestCase
       SSOPushCredential.stubs(:user_email).returns(@sso_push_user.email)
 
       @user = create(:user)
-      @application = create(:application, redirect_uri: "http://app.com/callback", with_supported_permissions: ['user_update_permission'])
+      @application = create(:application, redirect_uri: "https://app.com/callback", with_supported_permissions: ['user_update_permission'])
       @user_hash = UserOAuthPresenter.new(@user, @application).as_hash
     end
 
@@ -43,7 +43,7 @@ class SSOPushClientTest < ActiveSupport::TestCase
       SSOPushCredential.stubs(:user_email).returns(@sso_push_user.email)
 
       @user = create(:user)
-      @application = create(:application, redirect_uri: "http://app.com/callback", with_supported_permissions: ['user_update_permission'])
+      @application = create(:application, redirect_uri: "https://app.com/callback", with_supported_permissions: ['user_update_permission'])
     end
 
     should "send an empty POST to the app" do

--- a/test/unit/sso_push_error_test.rb
+++ b/test/unit/sso_push_error_test.rb
@@ -8,7 +8,7 @@ class SSOPushErrorTest < ActiveSupport::TestCase
     SSOPushCredential.stubs(:user_email).returns(@sso_push_user.email)
 
     @user = create(:user)
-    @application = create(:application, redirect_uri: "http://app.com/callback", with_supported_permissions: ['user_update_permission'])
+    @application = create(:application, redirect_uri: "https://app.com/callback", with_supported_permissions: ['user_update_permission'])
   end
 
   context "rescuing GdsApi::HTTPErrorResponse" do

--- a/test/unit/workers/permission_updater_test.rb
+++ b/test/unit/workers/permission_updater_test.rb
@@ -4,7 +4,7 @@ class PermissionUpdaterTest < ActiveSupport::TestCase
 
   def users_url(application)
     url = URI.parse(application.redirect_uri)
-    "http://#{url.host}/auth/gds/api/users/#{CGI.escape(@user.uid)}"
+    "https://#{url.host}/auth/gds/api/users/#{CGI.escape(@user.uid)}"
   end
 
   setup do
@@ -12,7 +12,7 @@ class PermissionUpdaterTest < ActiveSupport::TestCase
     SSOPushCredential.stubs(:user_email).returns(@sso_push_user.email)
 
     @user = create(:user)
-    @application = create(:application, redirect_uri: "http://app.com/callback", with_supported_permissions: ['user_update_permission'])
+    @application = create(:application, redirect_uri: "https://app.com/callback", with_supported_permissions: ['user_update_permission'])
     @permission = @user.grant_application_permission(@application, 'signin')
   end
 


### PR DESCRIPTION
there have been many enhancements and performance improvements to this gem:
https://github.com/doorkeeper-gem/doorkeeper/blob/master/CHANGELOG.md

many changes are to make it compatible with newer versions of Rails, so these are first steps to prepare for upgrading Signon to Rails 4.

some noteworthy backward incompatible changes:
- removing `doorkeeper_for` in favour of a `before_filter`
- forcing usage of SSL in redirect uri