### PR TITLE
Create user update supported permissions

### DIFF
--- a/db/migrate/20150204065936_add_user_update_supported_permission_to_applications.rb
+++ b/db/migrate/20150204065936_add_user_update_supported_permission_to_applications.rb
@@ -1,0 +1,9 @@
+require 'enhancements/application'
+
+class AddUserUpdateSupportedPermissionToApplications < ActiveRecord::Migration
+  def change
+    Doorkeeper::Application.where(supports_push_updates: true).each do |application|
+      application.supported_permissions.where(name: 'user_update_permission').first_or_create!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150121092250) do
+ActiveRecord::Schema.define(:version => 20150204065936) do
 
   create_table "batch_invitation_application_permissions", :force => true do |t|
     t.integer  "batch_invitation_id",     :null => false


### PR DESCRIPTION
users sending push updates to applications are [given 'user_update_permission' permission](https://github.com/alphagov/signonotron2/blob/master/lib/sso_push_credential.rb#L14) while generating
their access token.

gds-sso [checks for presence of this permission](https://github.com/alphagov/gds-sso/blob/6c37cfe4e8c74b9d530bac5ea9c7cb73b768c193/app/controllers/api/user_controller.rb#L44-L46) while authorising user API access.

earlier this worked because permissions were stored as strings, and there wasn't a 1-1 correspondence between granted permissions and an application's supported permission. now with permissions being stored as association records in a join table, every application that supports push updates must have a supported permission by the name 'user_update_permission'.

fixes: [errbit](https://errbit.preview.alphagov.co.uk/apps/52e678360da1158195000002/problems/54cbb4bb0da115e62c000d27)