### PR TITLE
Make sync_needed? work with unsynced permissions

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -26,6 +26,8 @@ module UsersHelper
   end
 
   def sync_needed?(permissions)
-    permissions.map(&:updated_at).max > permissions.map(&:last_synced_at).max
+    max_updated_at = permissions.map(&:updated_at).compact.max
+    max_last_synced_at = permissions.map(&:last_synced_at).compact.max
+    max_updated_at.present? && max_last_synced_at.present? ? max_updated_at > max_last_synced_at : false
   end
 end

--- a/test/unit/helpers/users_helper_test.rb
+++ b/test/unit/helpers/users_helper_test.rb
@@ -1,4 +1,10 @@
 require 'test_helper'
 
 class UsersHelperTest < ActionView::TestCase
+  test 'sync_needed? should work with user permissions not synced yet' do
+    application, user = create(:application), create(:user)
+    user.grant_application_permission(application, 'signin')
+
+    assert_nothing_raised { sync_needed?(user.application_permissions) }
+  end
 end


### PR DESCRIPTION
unsynced permissions raised method missing on nil errors. fixes: [errbit](https://errbit.preview.alphagov.co.uk/apps/52e678360da1158195000002/problems/54cf857f0da115411000159a)