### PR TITLE
Supported permissions can be hidden from admin UI

### DIFF
--- a/app/models/enhancements/application.rb
+++ b/app/models/enhancements/application.rb
@@ -17,6 +17,7 @@ class ::Doorkeeper::Application < ActiveRecord::Base
                                   .where(supported_permissions: { name: 'signin', delegatable: true })
 
   after_create :create_signin_supported_permission
+  after_save :create_user_update_supported_permission
 
   def self.policy_class; ApplicationPolicy; end
 
@@ -45,5 +46,9 @@ private
 
   def create_signin_supported_permission
     supported_permissions.create!(name: 'signin', delegatable: true)
+  end
+
+  def create_user_update_supported_permission
+    supported_permissions.where(name: 'user_update_permission', grantable_from_ui: true).first_or_create! if supports_push_updates?
   end
 end

--- a/app/models/enhancements/application.rb
+++ b/app/models/enhancements/application.rb
@@ -32,8 +32,8 @@ class ::Doorkeeper::Application < ActiveRecord::Base
     supported_permissions.where(name: 'signin').first
   end
 
-  def sorted_supported_permissions
-    ([signin_permission] + (supported_permissions.order(:name) - [signin_permission])).compact
+  def sorted_supported_permissions_grantable_from_ui
+    ([signin_permission] + (supported_permissions.grantable_from_ui.order(:name) - [signin_permission])).compact
   end
 
   def url_without_path

--- a/app/models/supported_permission.rb
+++ b/app/models/supported_permission.rb
@@ -9,6 +9,7 @@ class SupportedPermission < ActiveRecord::Base
 
   default_scope order(:name)
   scope :delegatable, -> { where(delegatable: true) }
+  scope :grantable_from_ui, -> { where(grantable_from_ui: true) }
 
 private
 

--- a/app/views/shared/_user_permissions.html.erb
+++ b/app/views/shared/_user_permissions.html.erb
@@ -37,7 +37,8 @@
         <% end %>
         <td>
           <%= label_tag "#{supported_permission_field_prefix}_ids", "Permissions for #{application.name}", class: "rm" %>
-          <% supported_permissions_options = application.supported_permissions.inject({}) {|h, per| h.merge(per.name => per.id) }
+          <% supported_permissions_options = application.supported_permissions.grantable_from_ui
+                                               .inject({}) {|h, per| h.merge(per.name => per.id) }
              supported_permissions_options.delete('signin') %>
           <%= select_tag supported_permission_field_name,
                           options_for_select(supported_permissions_options,

--- a/app/views/supported_permissions/index.html.erb
+++ b/app/views/supported_permissions/index.html.erb
@@ -32,7 +32,7 @@
     </tr>
   </thead>
   <tbody>
-    <% @application.sorted_supported_permissions.each do |supported_permission| %>
+    <% @application.sorted_supported_permissions_grantable_from_ui.each do |supported_permission| %>
       <tr>
         <td class="name">
           <%= link_to supported_permission.name, edit_doorkeeper_application_supported_permission_path(@application, supported_permission) %>

--- a/db/migrate/20150204115922_add_grantable_from_ui_to_supported_permissions.rb
+++ b/db/migrate/20150204115922_add_grantable_from_ui_to_supported_permissions.rb
@@ -1,0 +1,5 @@
+class AddGrantableFromUiToSupportedPermissions < ActiveRecord::Migration
+  def change
+    add_column :supported_permissions, :grantable_from_ui, :boolean, null: false, default: true
+  end
+end

--- a/db/migrate/20150204132812_add_user_update_supported_permission_to_applications.rb
+++ b/db/migrate/20150204132812_add_user_update_supported_permission_to_applications.rb
@@ -1,0 +1,9 @@
+require 'enhancements/application'
+
+class AddUserUpdateSupportedPermissionToApplications < ActiveRecord::Migration
+  def change
+    Doorkeeper::Application.where(supports_push_updates: true).each do |application|
+      application.supported_permissions.create!(name: 'user_update_permission', grantable_from_ui: false)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150204115922) do
+ActiveRecord::Schema.define(:version => 20150204132812) do
 
   create_table "batch_invitation_application_permissions", :force => true do |t|
     t.integer  "batch_invitation_id",     :null => false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150121092250) do
+ActiveRecord::Schema.define(:version => 20150204115922) do
 
   create_table "batch_invitation_application_permissions", :force => true do |t|
     t.integer  "batch_invitation_id",     :null => false
@@ -139,7 +139,8 @@ ActiveRecord::Schema.define(:version => 20150121092250) do
     t.string   "name"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "delegatable",    :default => false
+    t.boolean  "delegatable",       :default => false
+    t.boolean  "grantable_from_ui", :default => true,  :null => false
   end
 
   add_index "supported_permissions", ["application_id", "name"], :name => "index_supported_permissions_on_application_id_and_name", :unique => true

--- a/test/factories/oauth_applications.rb
+++ b/test/factories/oauth_applications.rb
@@ -2,6 +2,7 @@ FactoryGirl.define do
   factory :application, :class => Doorkeeper::Application do
     ignore do
       with_supported_permissions []
+      with_supported_permissions_not_grantable_from_ui []
       with_delegatable_supported_permissions []
     end
 
@@ -19,9 +20,13 @@ FactoryGirl.define do
         create(:supported_permission, application_id: app.id, name: permission_name)
       end
 
+      evaluator.with_supported_permissions_not_grantable_from_ui.each do |permission_name|
+        next if permission_name == 'signin'
+        create(:supported_permission, application_id: app.id, name: permission_name, grantable_from_ui: false)
+      end
+
       evaluator.with_delegatable_supported_permissions.each do |permission_name|
         next if permission_name == 'signin'
-
         create(:delegatable_supported_permission, application_id: app.id, name: permission_name)
       end
     end

--- a/test/factories/oauth_applications.rb
+++ b/test/factories/oauth_applications.rb
@@ -10,6 +10,7 @@ FactoryGirl.define do
     redirect_uri "https://app.com/callback"
     home_uri "https://app.com/"
     description "Important information about this app"
+    supports_push_updates false
 
     after(:create) do |app, evaluator|
       evaluator.with_supported_permissions.each do |permission_name|

--- a/test/integration/granting_permissions_test.rb
+++ b/test/integration/granting_permissions_test.rb
@@ -28,4 +28,11 @@ class GrantingPermissionsTest < ActionDispatch::IntegrationTest
 
     assert_include @user.permissions_for(app), 'write'
   end
+
+  should "not be able to assign fields that are not grantable_from_ui" do
+    create(:application, name: "MyApp", with_supported_permissions_not_grantable_from_ui: ['user_update_permission'])
+
+    visit edit_user_path(@user)
+    assert page.has_no_select?('Permissions for MyApp', :options => ['user_update_permission'])
+  end
 end

--- a/test/unit/doorkeeper_application_test.rb
+++ b/test/unit/doorkeeper_application_test.rb
@@ -6,6 +6,20 @@ class ::Doorkeeper::ApplicationTest < ActiveSupport::TestCase
     assert_not_nil create(:application).signin_permission
   end
 
+  context "user_update_permission" do
+    should "be created after save if application supports push updates" do
+      application = create(:application, supports_push_updates: false)
+      application.update_attributes(supports_push_updates: true)
+
+      application.reload
+      assert_include application.supported_permission_strings, 'user_update_permission'
+    end
+
+    should "not be created after save if application doesn't support push updates" do
+      assert_not_include create(:application, supports_push_updates: false).supported_permission_strings, 'user_update_permission'
+    end
+  end
+
   context "supported_permission_strings" do
 
     should "return a list of string permissions" do

--- a/test/unit/workers/push_user_updates_worker_test.rb
+++ b/test/unit/workers/push_user_updates_worker_test.rb
@@ -14,7 +14,7 @@ class PushUserUpdatesWorkerTest < ActiveSupport::TestCase
 
     should "perform_async updates on user's used applications" do
       user = create(:user)
-      foo_app, bar_app = *create_list(:application, 2)
+      foo_app, bar_app = *create_list(:application, 2, supports_push_updates: true)
 
       # authenticate access
       ::Doorkeeper::AccessToken.create!(resource_owner_id: user.id, application_id: foo_app.id, token: "1234")


### PR DESCRIPTION
we need a way to hide supported permissions from the admin ui, which should only be granted through code. as of now the only such supported permission is 'user_update_permission', which is granted to users accessing the user API in gds-sso: https://github.com/alphagov/signonotron2/blob/master/lib/sso_push_credential.rb

gds-sso checks for presence of this permission while authorising user API access: https://github.com/alphagov/gds-sso/blob/6c37cfe4e8c74b9d530bac5ea9c7cb73b768c193/app/controllers/api/user_controller.rb#L44-L46

we need to add a 'user_update_permission' supported permission to apps that support push updates. earlier this worked because permissions were stored as strings, and there wasn't a 1-1 correspondence between granted permissions and an application's supported permission. now with permissions being stored as association records in a join table, every application that supports push updates must have a supported permission by the name 'user_update_permission'.

fixes: [errbit](https://errbit.preview.alphagov.co.uk/apps/52e678360da1158195000002/problems/54cbb4bb0da115e62c000d27)