### PR TITLE
Hide supported permission "user_update_permission"

### DIFF
--- a/app/models/enhancements/application.rb
+++ b/app/models/enhancements/application.rb
@@ -49,6 +49,6 @@ private
   end
 
   def create_user_update_supported_permission
-    supported_permissions.where(name: 'user_update_permission', grantable_from_ui: true).first_or_create! if supports_push_updates?
+    supported_permissions.where(name: 'user_update_permission', grantable_from_ui: false).first_or_create! if supports_push_updates?
   end
 end

--- a/db/migrate/20150212133251_fix_user_update_permission.rb
+++ b/db/migrate/20150212133251_fix_user_update_permission.rb
@@ -1,0 +1,5 @@
+class FixUserUpdatePermission < ActiveRecord::Migration
+  def up
+    SupportedPermission.update_all({ grantable_from_ui: false }, { name: 'user_update_permission' })
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150204132812) do
+ActiveRecord::Schema.define(:version => 20150212133251) do
 
   create_table "batch_invitation_application_permissions", :force => true do |t|
     t.integer  "batch_invitation_id",     :null => false

--- a/test/unit/doorkeeper_application_test.rb
+++ b/test/unit/doorkeeper_application_test.rb
@@ -7,6 +7,11 @@ class ::Doorkeeper::ApplicationTest < ActiveSupport::TestCase
   end
 
   context "user_update_permission" do
+    should "not be grantable from ui" do
+      user_update_permission = create(:application, supports_push_updates: true).supported_permissions.detect {|perm| perm.name == 'user_update_permission' }
+      assert_false user_update_permission.grantable_from_ui?
+    end
+
     should "be created after save if application supports push updates" do
       application = create(:application, supports_push_updates: false)
       application.update_attributes(supports_push_updates: true)


### PR DESCRIPTION
after saving an application that supports push updates, we create a supported permission 'user_update_permission' for it. this was being created such that it was visible on the Signon interface, whereas it shouldn't have been. this permission is used internally by the system and does not mean anything to the users. this is due to a bug left-over from implementing grantable_from_ui: #326 

there's a migration to fix any invalid data that's been created in the meantime.