### PR TITLE
Drop permissions table

### DIFF
--- a/db/migrate/20150211091009_drop_permissions_table.rb
+++ b/db/migrate/20150211091009_drop_permissions_table.rb
@@ -1,0 +1,9 @@
+class DropPermissionsTable < ActiveRecord::Migration
+  def up
+    drop_table :permissions
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -121,19 +121,6 @@ ActiveRecord::Schema.define(:version => 20150212133251) do
   add_index "organisations", ["ancestry"], :name => "index_organisations_on_ancestry"
   add_index "organisations", ["slug"], :name => "index_organisations_on_slug", :unique => true
 
-  create_table "permissions", :force => true do |t|
-    t.integer  "user_id"
-    t.integer  "application_id"
-    t.text     "permissions"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.datetime "last_synced_at"
-  end
-
-  add_index "permissions", ["application_id", "user_id"], :name => "unique_permission_constraint", :unique => true
-  add_index "permissions", ["application_id"], :name => "index_permissions_on_application_id"
-  add_index "permissions", ["user_id"], :name => "index_permissions_on_user_id"
-
   create_table "supported_permissions", :force => true do |t|
     t.integer  "application_id"
     t.string   "name"

--- a/test/factories/permission.rb
+++ b/test/factories/permission.rb
@@ -1,5 +1,0 @@
-FactoryGirl.define do
-  factory :permission do
-    permissions ["signin"]
-  end
-end

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -84,7 +84,7 @@ FactoryGirl.define do
                 else
                   app_or_name
                 end
-          create(:permission, application: app, user: user, permissions: permission_names)
+          user.grant_application_permissions(app, permission_names)
         end
       end
     end

--- a/test/functional/authorisations_controller_test.rb
+++ b/test/functional/authorisations_controller_test.rb
@@ -60,12 +60,12 @@ class AuthorisationsControllerTest < ActionController::TestCase
         assert @api_user.has_access_to?(@application)
       end
 
-      should "not add a 'signin' permission for the authorised application if it already exists" do
-        create(:permission, application_id: @application.id, permissions: ['signin'], user_id: @api_user.id)
+      should "not duplicate 'signin' permission for the authorised application if it already exists" do
+        @api_user.grant_application_permission(@application, 'signin')
 
         post :create, api_user_id: @api_user.id, doorkeeper_access_token: { application_id: @application.id }
 
-        assert_equal 1, @api_user.permissions_for(@application).count
+        assert_equal ['signin'], @api_user.permissions_for(@application)
       end
     end
   end

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -143,7 +143,7 @@ class UsersControllerTest < ActionController::TestCase
 
     should "fetching json profile with a valid oauth token should succeed" do
       user = create(:user)
-      permission = create(:permission, user_id: user.id, application_id: @application.id)
+      user.grant_application_permission(@application, 'signin')
       token = create(:access_token, :application => @application, :resource_owner_id => user.id)
 
       @request.env['HTTP_AUTHORIZATION'] = "Bearer #{token.token}"
@@ -158,7 +158,7 @@ class UsersControllerTest < ActionController::TestCase
       # For now.  Once gds-sso is updated everywhere, this will 401.
 
       user = create(:user)
-      permission = create(:permission, user_id: user.id, application_id: @application.id)
+      user.grant_application_permission(@application, 'signin')
       token = create(:access_token, :application => @application, :resource_owner_id => user.id)
 
       @request.env['HTTP_AUTHORIZATION'] = "Bearer #{token.token}"


### PR DESCRIPTION
following this change: #311, user's application permissions are migrated join table instead of being stored as a serialised attribute in the permissions table.

dropping the permissions table which was kept as a backup. now that we've been running with remodelled permissions for a week and nothing's broken we should be good to clean that up.