### PR TITLE
Bugfix - viewing user with unsynced permissions

### DIFF
--- a/app/views/shared/_user_permissions.html.erb
+++ b/app/views/shared/_user_permissions.html.erb
@@ -52,12 +52,11 @@
         </td>
         <% if user_object.persisted? %>
           <td>
-            <% if permissions.map(&:last_synced_at).compact.present? %>
-              <% if sync_needed?(permissions) %>
-                <span class="label label-danger"><%= time_ago_in_words(permissions.first.last_synced_at) %> ago</span>
-              <% else %>
-                <span class="label label-success"><%= time_ago_in_words(permissions.first.last_synced_at) %> ago</span>
-              <% end %>
+            <% synced_permissions = permissions.select { |p| p.last_synced_at.present? } %>
+            <% if synced_permissions.any? %>
+              <span class="label <%= sync_needed?(synced_permissions) ? "label-danger" : "label-success" %>">
+                <%= time_ago_in_words(synced_permissions.map(&:last_synced_at).max) %> ago
+              </span>
             <% else %>
               <span class="label label-danger">Never</span>
             <% end %>


### PR DESCRIPTION
In some circumstances a crash could occur when viewing a user with unsynced
permissions. The precise scenario in which this could occur is if the first
permission in the users permission list was unsynced, and later ones were
synced.

In theory this should never occur because all permissions are synced at
the same time. However the association from user to application_permissions is
unordered, so the order in which the records are returned from mysql when
reading them could change arbitrarily.

The fix here is to make the display code more robust to this possible scenario.

I've also refactored the view slightly so that it's clear that only the
`<span>` label class changes according to the `sync_needed?` status.

https://www.pivotaltracker.com/story/show/88500338