### PR TITLE
Fix the Devise session extension bug in place

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,38 @@
 class SessionsController < Devise::SessionsController
 
+  # FIXME: remove this once we're at Devise 3.2.0 or higher. Please.
+  if Devise::VERSION == "2.2.5"
+    # Devise::SessionsController defines three filters, all using
+    # `prepend_before_filter`. The one we want (that skips Devise's timeout
+    # logic) is the last one defined, so it should be the first one in the
+    # callback chain
+    timeout_callback = _process_action_callbacks.first { |callback|
+      callback.klass == Devise::SessionsController
+    }
+
+    # Do a bunch of checks to make sure this is the callback that skips the
+    # timeout. In Devise 2.2.5, it's the only one defined as an anonymous Proc,
+    # and it's the only one without an :only or :except condition (which
+    # translate to :if and :unless respectively once they hit activesupport).
+    callback_checks = [
+      timeout_callback.present?,
+      timeout_callback.kind == :before,
+      timeout_callback.raw_filter.is_a?(Proc),
+      timeout_callback.per_key == {:if=>[], :unless=>[]},
+    ]
+    unless callback_checks.all?
+      raise "Something is wrong with the timeout callback: aborting"
+    end
+
+    # The `filter` method usually refers to the method on the controller that
+    # the filter invokes; when it's defined as an anonymous method, the name
+    # gets generated on the fly, making it harder to get hold of it.
+    timeout_callback_name = timeout_callback.filter
+    skip_before_filter timeout_callback_name, except: [:create, :destroy]
+  else
+    raise "This hack only applies to Devise 2.2.5: aborting"
+  end
+
   def destroy
     ReauthEnforcer.perform_on(current_user) if current_user
     super

--- a/test/integration/session_timeout_test.rb
+++ b/test/integration/session_timeout_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+class SessionTimeoutTest < ActionDispatch::IntegrationTest
+  setup do
+    @user_email = "email@example.com"
+    @user_password = "some passphrase with various $ymb0l$"
+    @user = create(:user, email: @user_email, password: @user_password)
+  end
+
+  should "not extend an expired session by viewing the login form" do
+    Timecop.freeze((User.timeout_in + 5.minutes).ago) do
+      visit root_path
+      signin(email: @user_email, password: @user_password)
+    end
+
+    visit "/users/sign_in"
+    refute_response_contains "You are already signed in"
+    assert_response_contains "Sign in"
+  end
+end


### PR DESCRIPTION
There is a security hole in versions of Devise prior to 3.2.0, in which a logged-in user sending a `GET` request to `/users/sign_in` would have their session extended, even if it had already expired; this also doesn't record anything in the event log, as the user hasn't technically signed in again. As a side-effect of this, people who have ended up using that URL as their bookmark for Signon get sent suspension warnings, as we don't have a record of them having logged into Signon.

Given the number of Devise plugins we use, and the customisations we've made on top of them, upgrading to a patched version of Devise is sufficiently complicated that it's worth patching this version in place in the meantime, so we aren't vulnerable while working on the upgrade.

The [commit in Devise that fixes this issue](https://github.com/plataformatec/devise/commit/52a3768451e4ef1e) restricts a filter so that it doesn't ignore session timeouts when displaying the login form, while still ignoring them when signing in or out. Ideally, we'd be able to throw in a `skip_before_filter` and be done, but this filter is defined as an  anonymous block, so we need to do some messing around in the guts of the callback chain to find the name Rails has assigned to the callback we're after.

This piece of code depends heavily on the order in which Devise defines the callbacks, so is locked to the version we're currently using, and is moderately paranoid when checking that the callback looks like the one we want: if anything isn't as expected, the patch will abort messily and break the app. This is a deliberate decision, so we can't miss it and cause unknown problems when we upgrade Devise itself. It's  also not been factored for readability, because the very next change to this app should be to upgrade Devise so that this code is no longer needed.