### PR TITLE
Remove application_permissions_attributes from roles

### DIFF
--- a/lib/roles/admin.rb
+++ b/lib/roles/admin.rb
@@ -3,7 +3,7 @@ module Roles
 
     def self.accessible_attributes
       [:uid, :name, :email, :password, :password_confirmation, :supported_permission_ids,
-      :application_permissions_attributes, :organisation_id, :unconfirmed_email, :confirmation_token]
+      :organisation_id, :unconfirmed_email, :confirmation_token]
     end
 
     def self.role_name

--- a/lib/roles/organisation_admin.rb
+++ b/lib/roles/organisation_admin.rb
@@ -3,7 +3,7 @@ module Roles
 
     def self.accessible_attributes
       [:uid, :name, :email, :password, :password_confirmation, :supported_permission_ids,
-      :application_permissions_attributes, :organisation_id, :unconfirmed_email, :confirmation_token]
+      :organisation_id, :unconfirmed_email, :confirmation_token]
     end
 
     def self.role_name

--- a/lib/roles/superadmin.rb
+++ b/lib/roles/superadmin.rb
@@ -3,7 +3,7 @@ module Roles
 
     def self.accessible_attributes
       [:uid, :name, :email, :password, :password_confirmation, :supported_permission_ids,
-        :application_permissions_attributes, :organisation_id, :unconfirmed_email, :confirmation_token,
+        :organisation_id, :unconfirmed_email, :confirmation_token,
         :role]
     end
 


### PR DESCRIPTION
These roles used to need to have `application_permissions_attributes` set
as `attr_accessible` on `User` so that they could update users' permissions
for applications. It hasn't been needed since d0df5b1b0569ffc08f04cace7e8665102188e138,
when `accepts_nested_attributes_for :application_permissions` was removed
from `User`. `:supported_permission_ids` is used instead now for updating
users' application permissions.