### PR TITLE
Re-add SQLite development dependency for GDS SSO build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@
 /.bundle
 .DS_Store
 
+# Ignore the default SQLite database.
+/db/*.sqlite3
+/db/*.sqlite3-journal
+
 # Ignore all logfiles and tempfiles.
 /log/*.log
 /tmp

--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,8 @@ end
 
 group :development do
   gem 'quiet_assets'
+  # SQLite is needed only for signon to be run as part of gds-sso's test suite
+  gem 'sqlite3'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,6 +237,7 @@ GEM
       multi_json (~> 1.0)
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
+    sqlite3 (1.3.9)
     statsd-ruby (1.1.0)
     strong_parameters (0.2.3)
       actionpack (~> 3.0)
@@ -314,6 +315,7 @@ DEPENDENCIES
   sidekiq-statsd (= 0.1.2)
   simplecov (= 0.6.4)
   simplecov-rcov (= 0.2.3)
+  sqlite3
   statsd-ruby (= 1.1.0)
   strong_parameters
   test-unit (= 2.5.2)


### PR DESCRIPTION
This was removed in 0c1748821932755ef146f68796c270044d84ff36 because it
appeared to be unused. However the tests for gds-sso spin up signon using
an SQLite database to test against, so this gem needs to stay in the
Gemfile here. Signon itself doesn't use SQLite otherwise.

/cc @alext 