### PR TITLE
Expose the org content_id in user.json

### DIFF
--- a/app/presenters/user_o_auth_presenter.rb
+++ b/app/presenters/user_o_auth_presenter.rb
@@ -10,6 +10,7 @@ class UserOAuthPresenter < Struct.new(:user, :application)
         email: user.email,
         permissions: permissions,
         organisation_slug: organisation_slug,
+        organisation_content_id: organisation_content_id,
         disabled: user.suspended?,
       }
     }
@@ -22,5 +23,10 @@ class UserOAuthPresenter < Struct.new(:user, :application)
   def organisation_slug
     organisation = user.organisation
     organisation.nil? ? nil : organisation.slug
+  end
+
+  def organisation_content_id
+    organisation = user.organisation
+    organisation.nil? ? nil : organisation.content_id
   end
 end

--- a/test/unit/user_o_auth_presenter_test.rb
+++ b/test/unit/user_o_auth_presenter_test.rb
@@ -16,6 +16,7 @@ class UserOAuthPresenterTest < ActiveSupport::TestCase
       name: user.name,
       uid: user.uid,
       organisation_slug: "justice-league",
+      organisation_content_id: justice_league.content_id,
       disabled: false,
     }
 


### PR DESCRIPTION
We want to move away from using slugs as they can change. content_ids are
stable.  Successfully tested in development.