### PR TITLE
Display when organisations have closed

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -14,9 +14,15 @@ class Organisation < ActiveRecord::Base
 
   def name_with_abbreviation
     if abbreviation.present? && abbreviation != name
-      "#{name} – #{abbreviation}"
+      return_value = "#{name} – #{abbreviation}"
     else
-      name
+      return_value = name
     end
+
+    if closed?
+      return_value += " (closed)"
+    end
+
+    return_value
   end
 end

--- a/db/migrate/20150501101146_add_closed_to_organisation.rb
+++ b/db/migrate/20150501101146_add_closed_to_organisation.rb
@@ -1,0 +1,5 @@
+class AddClosedToOrganisation < ActiveRecord::Migration
+  def change
+    add_column :organisations, :closed, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150421140645) do
+ActiveRecord::Schema.define(:version => 20150501101146) do
 
   create_table "batch_invitation_application_permissions", :force => true do |t|
     t.integer  "batch_invitation_id",     :null => false
@@ -109,14 +109,15 @@ ActiveRecord::Schema.define(:version => 20150421140645) do
   add_index "old_passwords", ["password_archivable_type", "password_archivable_id"], :name => "index_password_archivable"
 
   create_table "organisations", :force => true do |t|
-    t.string   "slug",              :null => false
-    t.string   "name",              :null => false
-    t.string   "organisation_type", :null => false
+    t.string   "slug",                                 :null => false
+    t.string   "name",                                 :null => false
+    t.string   "organisation_type",                    :null => false
     t.string   "abbreviation"
-    t.datetime "created_at",        :null => false
-    t.datetime "updated_at",        :null => false
+    t.datetime "created_at",                           :null => false
+    t.datetime "updated_at",                           :null => false
     t.string   "ancestry"
-    t.string   "content_id",        :null => false
+    t.string   "content_id",                           :null => false
+    t.boolean  "closed",            :default => false
   end
 
   add_index "organisations", ["ancestry"], :name => "index_organisations_on_ancestry"

--- a/lib/organisations_fetcher.rb
+++ b/lib/organisations_fetcher.rb
@@ -32,6 +32,7 @@ private
       name: organisation_data.title,
       organisation_type: organisation_data.format,
       abbreviation: organisation_data.details.abbreviation,
+      closed: organisation_data.details.govuk_status == 'closed',
     }
     organisation.update_attributes!(update_data)
   end

--- a/test/unit/organisation_test.rb
+++ b/test/unit/organisation_test.rb
@@ -35,5 +35,12 @@ class OrganisationTest < ActiveSupport::TestCase
       organisation = build(:organisation, name: 'An Organisation', abbreviation: 'An Organisation')
       assert_equal organisation.name, organisation.name_with_abbreviation
     end
+
+    context "when the organisation is closed" do
+      should "append (closed)" do
+        organisation = build(:organisation, name: 'An Organisation', closed: true)
+        assert_equal "An Organisation (closed)", organisation.name_with_abbreviation
+      end
+    end
   end
 end

--- a/test/unit/organisations_fetcher_test.rb
+++ b/test/unit/organisations_fetcher_test.rb
@@ -20,6 +20,7 @@ class OrganisationsFetcherTest < ActiveSupport::TestCase
       :organisation,
       name: 'Ministry Of Misery',
       slug: slug,
+      closed: true,
     )
     assert_equal(1, Organisation.count)
 
@@ -31,7 +32,9 @@ class OrganisationsFetcherTest < ActiveSupport::TestCase
     OrganisationsFetcher.new.call
 
     assert_equal(1, Organisation.count)
-    assert_equal('Ministry Of Fun', Organisation.find_by_slug(slug).name)
+    organisation.reload
+    assert_equal('Ministry Of Fun', organisation.name)
+    assert_equal(false, organisation.closed)
   end
 
   test "it updates an existing organisation when its slug changes" do


### PR DESCRIPTION
This makes it clearer when choosing organisations to assign to a user which
ones are plausible. An example of this is Highways Agency which has become a
different organisation called Highways England.

This could happen more when the new government is formed and organisations are
closed and created with potentially similar/confusing names.

![screen shot 2015-05-01 at 11 26 14](https://cloud.githubusercontent.com/assets/93739/7429209/a8667ef6-eff5-11e4-8675-3a442b6a194d.png)