### PR TITLE
Make password expiry tests more robust

### DIFF
--- a/test/functional/passwords_controller_test.rb
+++ b/test/functional/passwords_controller_test.rb
@@ -25,7 +25,7 @@ class PasswordsControllerTest < ActionController::TestCase
   end
 
   test 'a partially signed-in user with an expired password trying to reset their password should get signed-out' do
-    @user.update_attribute(:password_changed_at, 3.months.ago)
+    @user.update_attribute(:password_changed_at, 91.days.ago)
 
     # simulate a partially signed-in user. for example,
     # user with an expired password being asked to change the password
@@ -36,7 +36,7 @@ class PasswordsControllerTest < ActionController::TestCase
   end
 
   test 'a partially signed-in user with an expired password trying to reset their password should not be redirected to after_sign_in_path' do
-    @user.update_attribute(:password_changed_at, 3.months.ago)
+    @user.update_attribute(:password_changed_at, 91.days.ago)
     sign_in @user
 
     get :edit, id: @user.id, reset_password_token: @user.reset_password_token
@@ -46,7 +46,7 @@ class PasswordsControllerTest < ActionController::TestCase
   end
 
   test 'a partially signed-in user with an expired password should be able to request password reset instructions' do
-    @user.update_attribute(:password_changed_at, 3.months.ago)
+    @user.update_attribute(:password_changed_at, 91.days.ago)
 
     # simulate a partially signed-in user. for example,
     # user with an expired password being asked to change the password

--- a/test/integration/passphrase_reset_test.rb
+++ b/test/integration/passphrase_reset_test.rb
@@ -45,7 +45,7 @@ class PassphraseResetTest < ActionDispatch::IntegrationTest
 
   should "work for a partially signed-in user with an expired passphrase" do
     Sidekiq::Testing.inline! do
-      user = create(:user, password_changed_at: 3.months.ago)
+      user = create(:user, password_changed_at: 91.days.ago)
 
       trigger_reset_for(user.email)
 
@@ -109,7 +109,7 @@ class PassphraseResetTest < ActionDispatch::IntegrationTest
   end
 
   should "be accessible from the change password screen by a partially signed-in user" do
-    user = create(:user, password_changed_at: 3.months.ago)
+    user = create(:user, password_changed_at: 91.days.ago)
 
     visit root_path
     signin(email: user.email, password: user.password)


### PR DESCRIPTION
These tests started failing today without any changes. This seems to be because
the tests were setting the password to have expired `3.months.ago` and Devise
`expire_password_after` is set to `90.days`, which is usually but not always
the same.

Today, this is what Rails returned:
```
Loading development environment (Rails 3.2.18)
irb(main):001:0> 3.months.ago
=> Sun, 01 Feb 2015 14:24:23 GMT +00:00
irb(main):002:0> 90.days.ago
=> Sat, 31 Jan 2015 14:24:26 GMT +00:00
```

We think that the intention was for it to set the password_changed_at to be
further in the past than the expiry time, so we changed it to 91 to make it
clearer.