### PR TITLE
Store devise secret_key in an environment variable

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -307,7 +307,7 @@ Devise.setup do |config|
   # Time period for account expiry from last_activity_at
   # config.expire_after = 90.days
 
-  config.secret_key = '9c46442808d803d907849ad47dc929851e1603686b8be5913347884cfe4d6f108ca3edeb8749c22430f215c1c90a0d1b456c103c5e30317027459087f24c7240'
+  config.secret_key = ENV['DEVISE_SECRET_KEY']
   config.allow_insecure_token_lookup = true
   config.allow_insecure_sign_in_after_confirmation = true
 end

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -6,6 +6,7 @@ git clean -fdx
 
 export USE_SIMPLECOV=true
 export RAILS_ENV=test
+export DEVISE_SECRET_KEY=devise-test
 bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
 bundle exec rake stats
 bundle exec rake db:drop db:create db:schema:load


### PR DESCRIPTION
Part of upgrading devise.

Previous `secret_key` was auto-generated. Load the key from an environment variable instead.