### PR TITLE
Update Airbrake params filtering to match Production

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -42,6 +42,8 @@ module Signonotron2
     config.encoding = "utf-8"
 
     # Configure sensitive parameters which will be filtered from the log file.
+    # Note: filter_parameters are treated as regexes, so :password also matches
+    # current_password, password_confirmation and password-strength-score
     config.filter_parameters += [:password]
 
     # Use SQL instead of Active Record's schema dumper when creating the database.

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -4,4 +4,5 @@ Airbrake.configure do |config|
   # Adding production to the development environments causes Airbrake not
   # to attempt to send notifications.
   config.development_environments << "production"
+  config.params_filters += ["current_password", "password-strength-score"]
 end


### PR DESCRIPTION
We already have this `params_filters` config in the Airbrake initializer in
production environments, so it should be here too for consistency. Including
`password-strength-score` in the Airbrake filter is done for consistency with
the Rails parameter filtering.

Also add a comment documenting the fact that our existing parameter
filtering for Rails logging already matches all the sensitive password
params.