### PR TITLE
Make invalid and missing error messages the same

### DIFF
--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -19,6 +19,7 @@ en:
       unconfirmed: 'You have to confirm your account before continuing.'
       locked: 'Your account is temporarily locked.'
       invalid: 'Invalid email or passphrase.'
+      not_found_in_database: 'Invalid email or passphrase.'
       invalid_token: 'Invalid authentication token.'
       timeout: 'Your session expired, please sign in again to continue.'
       inactive: 'Your account was not activated yet.'

--- a/test/integration/sign_in_test.rb
+++ b/test/integration/sign_in_test.rb
@@ -17,6 +17,20 @@ class SignInTest < ActionDispatch::IntegrationTest
     assert_response_contains("Invalid email or passphrase")
   end
 
+  should "display the same rejection for failed logins, empty passwords, and missing accounts" do
+    visit root_path
+    signin(email: "does-not-exist@example.com", password: "some made up p@ssw0rd")
+    assert_response_contains("Invalid email or passphrase")
+
+    visit root_path
+    signin(email: "email@example.com", password: "some incorrect passphrase with various $ymb0l$")
+    assert_response_contains("Invalid email or passphrase")
+
+    visit root_path
+    signin(email: "email@example.com", password: "")
+    assert_response_contains("Invalid email or passphrase")
+  end
+
   should "succeed if the Client-IP header is set" do
     page.driver.browser.header("Client-IP", "127.0.0.1")
 


### PR DESCRIPTION
In order to avoid username enumeration attacks on Signon, make all error
messages on the login screen the same.

The keys were gotten from:

https://github.com/plataformatec/devise/blob/4acb5043249d6fb5636d9f066aafcb0a11ba2765/config/locales/en.yml#L12-L15

but we had previously only overridden one of them.