### PR TITLE
Fix queries using application.id on User model

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -81,7 +81,7 @@ class User < ActiveRecord::Base
   end
 
   def permissions_synced!(application)
-    application_permissions.where(id: application.id).update_all(last_synced_at: Time.zone.now)
+    application_permissions.where(application_id: application.id).update_all(last_synced_at: Time.zone.now)
   end
 
   def authorised_applications

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -73,7 +73,7 @@ class User < ActiveRecord::Base
   end
 
   def permission_ids_for(application)
-    application_permissions.where(id: application.id).pluck(:supported_permission_id)
+    application_permissions.where(application_id: application.id).pluck(:supported_permission_id)
   end
 
   def has_access_to?(application)

--- a/test/integration/granting_permissions_test.rb
+++ b/test/integration/granting_permissions_test.rb
@@ -20,13 +20,17 @@ class GrantingPermissionsTest < ActionDispatch::IntegrationTest
   end
 
   should "support granting app-specific permissions" do
-    app = create(:application, name: "MyApp", with_supported_permissions: ["write"])
+    app = create(:application, name: "MyApp",
+                 with_supported_permissions: ["pre-existing", "adding", "never"])
+    @user.grant_application_permission(app, "pre-existing")
 
     visit edit_user_path(@user)
-    select "write", from: "Permissions for MyApp"
+    select "adding", from: "Permissions for MyApp"
     click_button "Update User"
 
-    assert_includes @user.permissions_for(app), 'write'
+    assert_includes @user.permissions_for(app), "pre-existing"
+    assert_includes @user.permissions_for(app), "adding"
+    assert_not_includes @user.permissions_for(app), "never"
   end
 
   should "not be able to assign fields that are not grantable_from_ui" do


### PR DESCRIPTION
These were accidentally broken in e96e674 - see commit messages for full details.