### PR TITLE
Simplify setting devise secret key

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -307,5 +307,9 @@ Devise.setup do |config|
   # Time period for account expiry from last_activity_at
   # config.expire_after = 90.days
 
-  config.secret_key = ENV['DEVISE_SECRET_KEY']
+  config.secret_key = if Rails.env.production?
+                        ENV['DEVISE_SECRET_KEY']
+                      else
+                        'fake-secret-key'
+                      end
 end

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -6,7 +6,6 @@ git clean -fdx
 
 export USE_SIMPLECOV=true
 export RAILS_ENV=test
-export DEVISE_SECRET_KEY=devise-test
 bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
 bundle exec rake stats
 bundle exec rake db:drop db:create db:schema:load


### PR DESCRIPTION
We only really care about the secret key being an environment variable in production. Set to a default dummy value in development and test.