### PR TITLE
Prevent unverified email changes

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,7 +18,7 @@ module ApplicationHelper
     if policy(current_user).edit?
       edit_user_path(current_user)
     else
-      root_path
+      edit_email_or_passphrase_user_path(current_user)
     end
   end
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -16,19 +16,34 @@ class UserPolicy < BasePolicy
       current_user.id == record.id ||
         (record.normal? && belong_to_same_organisation_subtree?(current_user, record))
     when 'normal'
-      current_user.id == record.id
+      false
     end
   end
   alias_method :create?, :edit? # invitations#create
   alias_method :update?, :edit?
   alias_method :unlock?, :edit?
   alias_method :suspension?, :edit?
-  alias_method :edit_email_or_passphrase?, :edit?
-  alias_method :update_email?, :edit?
-  alias_method :update_passphrase?, :edit?
-  alias_method :cancel_email_change?, :edit?
-  alias_method :resend_email_change?, :edit?
   alias_method :resend?, :edit?
+
+  def edit_email_or_passphrase?
+    current_user.id == record.id
+  end
+
+  def update_email?
+    current_user.id == record.id
+  end
+
+  def update_passphrase?
+    current_user.id == record.id
+  end
+
+  def cancel_email_change?
+    (current_user.id == record.id) || edit?
+  end
+
+  def resend_email_change?
+    (current_user.id == record.id) || edit?
+  end
 
   def event_logs?
     current_user.normal? ? false : edit?

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -23,7 +23,7 @@ describe UserPolicy do
     end
   end
 
-  user_management_actions = [:edit?, :create?, :update?, :unlock?, :suspension?, :update_passphrase?,
+  user_management_actions = [:edit?, :create?, :update?, :unlock?, :suspension?,
     :cancel_email_change?, :resend_email_change?, :event_logs?]
 
   user_management_actions.each do |permission_name|
@@ -64,11 +64,22 @@ describe UserPolicy do
     end
   end
 
-  (user_management_actions - [:event_logs?]).each do |permission_name|
+  self_management_actions = [:edit_email_or_passphrase?, :update_email?, :update_passphrase?, :cancel_email_change?, :resend_email_change?]
+  self_management_actions.each do |permission_name|
     permissions permission_name do
       it "is allowed for normal users accessing their own record" do
         normal_user = create(:user)
         expect(subject).to permit(normal_user, normal_user)
+      end
+    end
+  end
+
+  # Users shouldn't be able to do admin-only things to themselves
+  (user_management_actions - self_management_actions).each do |permission_name|
+    permissions permission_name do
+      it "is not allowed for normal users accessing their own record" do
+        normal_user = create(:user)
+        expect(subject).not_to permit(normal_user, normal_user)
       end
     end
   end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -48,7 +48,7 @@ class UsersControllerTest < ActionController::TestCase
     end
   end
 
-  context "GET edit" do
+  context "GET edit_email_or_passphrase" do
     context "changing an email" do
       setup do
         @user = create(:user_with_pending_email_change)
@@ -56,7 +56,7 @@ class UsersControllerTest < ActionController::TestCase
       end
 
       should "show the unconfirmed_email" do
-        get :edit, id: @user.id
+        get :edit_email_or_passphrase, id: @user.id
 
         assert_select "input#user_unconfirmed_email[value=#{@user.unconfirmed_email}]"
       end

--- a/test/integration/email_change_test.rb
+++ b/test/integration/email_change_test.rb
@@ -150,7 +150,7 @@ class EmailChangeTest < ActionDispatch::IntegrationTest
 
       confirmation_token = token_sent_to(@user)
 
-      visit edit_user_path(@user)
+      click_link "Change your email or passphrase"
       click_link "Cancel email change"
       signout
 

--- a/test/integration/password_expiry_test.rb
+++ b/test/integration/password_expiry_test.rb
@@ -25,12 +25,12 @@ class PassphraseExpiryTest < ActionDispatch::IntegrationTest
     end
 
     should "remember where the user was trying to get to before the password reset" do
-      visit "/users/#{@user.id}/edit?arbitrary=1"
+      visit "/users/#{@user.id}/edit_email_or_passphrase?arbitrary=1"
 
       signin(@user)
       reset_expired_passphrase(@user.password, @new_password, @new_password)
 
-      assert_current_url "/users/#{@user.id}/edit?arbitrary=1"
+      assert_current_url "/users/#{@user.id}/edit_email_or_passphrase?arbitrary=1"
     end
 
     should "continue prompting for a new password if the reset didn't work" do


### PR DESCRIPTION
Normal users shouldn't be able to directly change their own email address - they have to confirm the change via a link sent to the new email address (a notification is also sent to their old address).

Admins have been able to make email changes without requiring the user to confirm for some time. 

We accidentally gave normal users access to/a link to the admin-style page for themselves, which allows them to change their own email without confirmation.

By preventing their access to the full fledged edit page, we also mitigate some usability problems for normal users - it included various fields and links which would lead to the user seeing errors.

cc @jennyd @bishboria 