### PR TITLE
Remove sqlite dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,8 +45,6 @@ gem 'uglifier', '2.7.1'
 
 group :development do
   gem 'quiet_assets', '1.0.2'
-  # SQLite is needed only for signon to be run as part of gds-sso's test suite
-  gem 'sqlite3'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -255,7 +255,6 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
-    sqlite3 (1.3.9)
     statsd-ruby (1.1.0)
     systemu (2.5.2)
     thor (0.19.1)
@@ -334,7 +333,6 @@ DEPENDENCIES
   sidekiq-statsd (= 0.1.2)
   simplecov (= 0.6.4)
   simplecov-rcov (= 0.2.3)
-  sqlite3
   statsd-ruby (= 1.1.0)
   timecop (= 0.7.1)
   uglifier (= 2.7.1)


### PR DESCRIPTION
Originally Signon used this in development, but this was removed some years ago: 7b55f8dcd9c0368370738a77104d85fc1dd2fbb3. gds-sso has been using sqlite to run Signon in its integration tests, but this has now been switched to MySQL: https://github.com/alphagov/gds-sso/pull/73

The build is currently failing because the gds-sso build is failing because of a bug relating to Doorkeeper. This change is housekeeping, so can happily wait until everything else has settled before being merged.