### PR TITLE
Explicitly mark session cookies as "Secure"

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,4 @@
 # Be sure to restart your server when you modify this file.
 
-Signonotron2::Application.config.session_store :cookie_store, key: '_signonotron2_session'
+Signonotron2::Application.config.session_store :cookie_store, key: '_signonotron2_session',
+                                                secure: Rails.env.production?


### PR DESCRIPTION
This means that cookies will only be sent over encrypted connections, thus
making it harder for an attacker to read/replay someone else's session.

The secure option was accidentally removed in 0ad105f.