### PR TITLE
Restore logstasher config

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -75,6 +75,10 @@ Signonotron2::Application.configure do
   # Disable automatic flushing of the log to improve performance.
   # config.autoflush_log = false
 
+  config.logstasher.enabled = true
+  config.logstasher.logger = Logger.new("#{Rails.root}/log/#{Rails.env}.json.log")
+  config.logstasher.suppress_app_log = true
+
   config.action_mailer.default_url_options = {
     :host => URI.parse(Plek.current.find('signon')).host,
     :protocol => 'https'


### PR DESCRIPTION
When this was removed, we stopped creating our JSON logs.

This config was accidentally deleted in 0ad105f7d7e7e692899e1f7d07cc197c903c9bbe.