### PR TITLE
Bump GDS API adapters to 20.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'pundit', '0.3.0'
 gem 'doorkeeper', '2.2.1'
 gem 'ancestry', '2.0.0'
 
-gem 'gds-api-adapters', '18.4.0'
+gem 'gds-api-adapters', '20.1.1'
 gem 'statsd-ruby', '1.1.0'
 gem 'unicorn', '4.3.1'
 gem 'sidekiq', '2.17.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,7 +113,7 @@ GEM
     factory_girl_rails (4.3.0)
       factory_girl (~> 4.3.0)
       railties (>= 3.0.0)
-    gds-api-adapters (18.4.0)
+    gds-api-adapters (20.1.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -184,7 +184,7 @@ GEM
       activesupport (>= 3.0.0)
     quiet_assets (1.0.2)
       railties (>= 3.1, < 5.0)
-    rack (1.5.4)
+    rack (1.5.5)
     rack-cache (1.2)
       rack (>= 0.4)
     rack-test (0.6.3)
@@ -319,7 +319,7 @@ DEPENDENCIES
   devise_zxcvbn (= 1.1.1)
   doorkeeper (= 2.2.1)
   factory_girl_rails (= 4.3.0)
-  gds-api-adapters (= 18.4.0)
+  gds-api-adapters (= 20.1.1)
   govuk_admin_template (= 2.3.1)
   jasmine (= 2.1.0)
   json (= 1.8.0)


### PR DESCRIPTION
This changes the user agent to include the app
name in API requests.

https://trello.com/c/qkHdtob4/247-bump-gds-api-adapters-everywhere-it-s-used-to-include-user-agent-information