### PR TITLE
Clearer password reset error message

### DIFF
--- a/app/views/devise/passwords/reset_error.html.erb
+++ b/app/views/devise/passwords/reset_error.html.erb
@@ -5,6 +5,6 @@
 </div>
 
 <div class="alert alert-warning">
-  <p>That passphrase reset didn’t work. It may be that the link you were using has expired or was invalid.</p>
+  <p>That passphrase reset didn’t work. It may be that you’ve used this passphrase already, or the link you were using has expired or was invalid.</p>
   <p class="add-top-margin"><%= link_to 'Try again', new_user_password_path, class: 'btn btn-default' %></p>
 </div>


### PR DESCRIPTION
The previous message was also displayed if you reused the previous
password. This commit updates it to also include this possible solution
to the error.