### PR TITLE
Add rake task to migrate apps to new domain.

### DIFF
--- a/lib/tasks/applications.rake
+++ b/lib/tasks/applications.rake
@@ -20,4 +20,19 @@ namespace :applications do
     puts "config.oauth_id     = '#{a.uid}'"
     puts "config.oauth_secret = '#{a.secret}'"
   end
+
+  desc 'Updates domain name for applications'
+  task :migrate_domain => :environment do
+    raise "Requires OLD_DOMAIN + NEW_DOMAIN specified in environment" unless ENV['OLD_DOMAIN'] && ENV['NEW_DOMAIN']
+    Doorkeeper::Application.find_each do |application|
+      [:redirect_uri, :home_uri].each do |field|
+        new_domain = application[field].gsub(ENV['OLD_DOMAIN'], ENV['NEW_DOMAIN'])
+        if application[field] != new_domain
+          puts "Migrating #{application.name} - #{field} to new domain: #{new_domain}"
+          application[field] = new_domain
+        end
+      end
+      application.save!
+    end
+  end
 end


### PR DESCRIPTION
As part of our migration to Carrenza we are taking
the opportunity to sort out some of our domains,
namely kill alphagov. We need to have a way to
update all signon apps redirect_uri and home_ui.

For a domain currently set to `bar.co.uk`

```
~/govuk/signonotron2(branch:add_rake_task_to_migrate_domain*) » export OLD_DOMAIN="bar.co.uk"
------------------------------------------------------------
~/govuk/signonotron2(branch:add_rake_task_to_migrate_domain*) » export NEW_DOMAIN="foobarbaz"
------------------------------------------------------------
~/govuk/signonotron2(branch:add_rake_task_to_migrate_domain*) » bundle exec rake applications:migrate_domain
Migrating Publisher - redirect_uri to new domain: https://publisher.foobarbaz/auth/gds/callback
Migrating Publisher - home_uri to new domain: https://publisher.foobarbaz
Migrating Whitehall - redirect_uri to new domain: https://whitehall-admin.foobarbaz/auth/gds/callback
Migrating Whitehall - home_uri to new domain: https://whitehall-admin.foobarbaz
Migrating Panopticon - redirect_uri to new domain: https://panopticon.foobarbaz/auth/gds/callback
Migrating Panopticon - home_uri to new domain: https://panopticon.foobarbaz
Migrating Imminence - redirect_uri to new domain: https://imminence.foobarbaz/auth/gds/callback
Migrating Imminence - home_uri to new domain: https://imminence.foobarbaz
Migrating Licensing - redirect_uri to new domain: https://licensify-admin.foobarbaz/licence-management/admin/oauth
Migrating Licensing - home_uri to new domain: https://licensify-admin.foobarbaz
Migrating Content API - redirect_uri to new domain: https://contentapi.foobarbaz/notapplicable
Migrating Content API - home_uri to new domain: https://contentapi.foobarbaz
Migrating Support - redirect_uri to new domain: https://support.foobarbaz/auth/gds/callback
Migrating Support - home_uri to new domain: https://support.foobarbaz
Migrating Release - redirect_uri to new domain: https://release.foobarbaz/auth/gds/callback
Migrating Release - home_uri to new domain: https://release.foobarbaz
Migrating Travel Advice Publisher - redirect_uri to new domain: https://travel-advice-publisher.foobarbaz/auth/gds/callback
Migrating Travel Advice Publisher - home_uri to new domain: https://travel-advice-publisher.foobarbaz
Migrating Asset Manager - redirect_uri to new domain: https://asset-manager.foobarbaz/auth/gds/callback
Migrating Asset Manager - home_uri to new domain: https://asset-manager.foobarbaz/
Migrating Kibana - redirect_uri to new domain: https://kibana.foobarbaz/auth/gds/callback
Migrating Kibana - home_uri to new domain: https://kibana.foobarbaz
Migrating transition - redirect_uri to new domain: https://transition.foobarbaz/auth/gds/callback
Migrating transition - home_uri to new domain: https://transition.foobarbaz
Migrating Performance Platform (deprecated) - redirect_uri to new domain: https://backdrop-admin.foobarbaz/_user/authorized
Migrating Performance Platform (deprecated) - home_uri to new domain: https://backdrop-admin.foobarbaz/_user/sign_in
Migrating Need API - redirect_uri to new domain: https://need-api.foobarbaz/auth/gds/callback
Migrating Need API - home_uri to new domain: https://need-api.foobarbaz
Migrating Maslow - redirect_uri to new domain: https://maslow.foobarbaz/auth/gds/callback
Migrating Maslow - home_uri to new domain: https://maslow.foobarbaz
Migrating Trade Tariff Admin - redirect_uri to new domain: https://tariff-admin.foobarbaz/auth/gds/callback
Migrating Trade Tariff Admin - home_uri to new domain: https://tariff-admin.foobarbaz
Migrating Errbit - redirect_uri to new domain: https://errbit.foobarbaz/users/auth/gds/callback
Migrating Errbit - home_uri to new domain: https://errbit.foobarbaz/
Migrating ContentPlanner - redirect_uri to new domain: https://content-planner.foobarbaz/auth/gds/callback
Migrating ContentPlanner - home_uri to new domain: https://content-planner.foobarbaz
Migrating Specialist publisher - redirect_uri to new domain: https://specialist-publisher.foobarbaz/auth/gds/callback
Migrating Specialist publisher - home_uri to new domain: https://specialist-publisher.foobarbaz
Migrating Contacts - redirect_uri to new domain: https://contacts-admin.foobarbaz/auth/gds/callback
Migrating Contacts - home_uri to new domain: https://contacts-admin.foobarbaz/admin
Migrating Search Admin - redirect_uri to new domain: https://search-admin.foobarbaz/auth/gds/callback
Migrating Search Admin - home_uri to new domain: https://search-admin.foobarbaz/
Migrating TariffBackend - redirect_uri to new domain: https://tariff-api.foobarbaz/auth/gds/callback
Migrating TariffBackend - home_uri to new domain: https://tariff-api.foobarbaz/
Migrating Collections publisher - redirect_uri to new domain: https://collections-publisher.foobarbaz/auth/gds/callback
Migrating Collections publisher - home_uri to new domain: https://collections-publisher.foobarbaz
Migrating Short URL Manager - redirect_uri to new domain: https://short-url-manager.foobarbaz/auth/gds/callback
Migrating Short URL Manager - home_uri to new domain: https://short-url-manager.foobarbaz
Migrating Collections API - redirect_uri to new domain: https://collections-api.foobarbaz/auth/gds/callback
Migrating Collections API - home_uri to new domain: https://collections-api.foobarbaz
Migrating HMRC Manuals API - redirect_uri to new domain: https://hmrc-manuals-api.foobarbaz
Migrating HMRC Manuals API - home_uri to new domain: https://hmrc-manuals-api.foobarbaz
Migrating Courts API - redirect_uri to new domain: https://courts-api.foobarbaz
Migrating Courts API - home_uri to new domain: https://courts-api.foobarbaz
Migrating Policy Publisher - redirect_uri to new domain: https://policy-publisher.foobarbaz/auth/gds/callback
Migrating Policy Publisher - home_uri to new domain: https://policy-publisher.foobarbaz
```