### PR TITLE
Ensure oauth authorisation respects password expiry

### DIFF
--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -6,7 +6,12 @@ Doorkeeper.configure do
     # If you want to use named routes from your app you need
     # to call them on routes object eg.
     # routes.new_user_session_path
-    current_user || warden.authenticate!(:scope => :user)
+    user = current_user || warden.authenticate!(:scope => :user)
+    if user.need_change_password?
+      redirect_to user_password_expired_path
+    else
+      user
+    end
   end
 
   # If you want to restrict the access to the web interface for

--- a/test/integration/authorise_application_test.rb
+++ b/test/integration/authorise_application_test.rb
@@ -20,6 +20,19 @@ class AuthoriseApplicationTest < ActionDispatch::IntegrationTest
     assert_kind_of Doorkeeper::AccessGrant, Doorkeeper::AccessGrant.find_by(resource_owner_id: @user.id)
   end
 
+  should "not confirm the authorisation if the user's passphrase has expired" do
+    @user.password_changed_at = 91.days.ago
+    @user.save!
+
+    visit "/"
+    signin(@user)
+    ignoring_spurious_error do
+      visit "/oauth/authorize?response_type=code&client_id=#{@app.uid}&redirect_uri=#{@app.redirect_uri}"
+    end
+    assert_response_contains("Choose a new passphrase")
+    refute Doorkeeper::AccessGrant.find_by(resource_owner_id: @user.id)
+  end
+
   should "confirm the authorisation for a signed-in user" do
     visit "/"
     signin(@user)


### PR DESCRIPTION
Trello: https://trello.com/c/wQufRA6Z/65-signon-client-apps-don-t-respect-passphrase-expiry

When Doorkeeper performs authentication and authorization of a user in
order to allow them access to an application, it doesn’t check whether
the user’s password is expired.

This change adds a check to the configuration of Doorkeeper, where it
will redirect the user to the passphrase expiry screen when they
attempt to access an application if required.

/cc @jamiecobbett @bradleywright 