### PR TITLE
Add optional argument for apps not to update domain.

### DIFF
--- a/lib/tasks/applications.rake
+++ b/lib/tasks/applications.rake
@@ -20,10 +20,11 @@ namespace :applications do
     puts "config.oauth_secret = '#{a.secret}'"
   end
 
-  desc 'Updates domain name for applications'
-  task migrate_domain: :environment do
+  desc 'Updates domain name for applications, optionally pass CSV of apps to ignore'
+  task :migrate_domain, [:apps_to_ignore] => :environment do |_t, args|
+    apps_to_ignore = args.any? ? args[:apps_to_ignore].split(',') : []
     raise "Requires OLD_DOMAIN + NEW_DOMAIN specified in environment" unless ENV['OLD_DOMAIN'] && ENV['NEW_DOMAIN']
-    Doorkeeper::Application.find_each do |application|
+    Doorkeeper::Application.where.not(name: apps_to_ignore).find_each do |application|
       [:redirect_uri, :home_uri].each do |field|
         new_domain = application[field].gsub(ENV['OLD_DOMAIN'], ENV['NEW_DOMAIN'])
         if application[field] != new_domain


### PR DESCRIPTION
We need a way to skip certain apps i.e. licensify 
as that is staying at the old domain name. The 
argument to skip apps is optional. If want
to skip an application the arguments are passed in
as so: 

rake applications:migrate_domain['licensify, foo']