### PR TITLE
Add some more logging on password reset flows

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -1,5 +1,6 @@
 class PasswordsController < Devise::PasswordsController
   before_filter :record_password_reset_request, only: :create
+  before_filter :record_reset_page_loaded, only: :edit
 
   # overrides http://git.io/sOhoaA to prevent expirable from
   # intercepting reset password flow for a partially signed-in user
@@ -13,16 +14,30 @@ class PasswordsController < Devise::PasswordsController
 
   def update
     super do |resource|
-      render('devise/passwords/reset_error') && return unless resource.valid?
+      unless resource.valid?
+        record_password_reset_failure(resource) if resource.persisted?
+        render 'devise/passwords/reset_error'
+        return
+      end
     end
   end
 
-  private
+private
   def record_password_reset_request
     user_from_params = User.find_by_email(params[:user][:email]) if params[:user].present?
     EventLog.record_event(user_from_params, EventLog::PASSPHRASE_RESET_REQUEST) if user_from_params
     Statsd.new(::STATSD_HOST).increment(
       "#{::STATSD_PREFIX}.users.password_reset_request"
     )
+  end
+
+  def record_reset_page_loaded
+    token = Devise.token_generator.digest(self, :reset_password_token, params[:reset_password_token])
+    user_from_params = User.find_by(reset_password_token: token)
+    EventLog.record_event(user_from_params, EventLog::PASSPHRASE_RESET_LOADED) if user_from_params
+  end
+
+  def record_password_reset_failure(user)
+    EventLog.record_event(user, EventLog::PASSPHRASE_RESET_FAILURE)
   end
 end

--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -8,6 +8,8 @@ class EventLog < ActiveRecord::Base
   MANUAL_ACCOUNT_UNLOCK = "Manual account unlock"
   PASSPHRASE_EXPIRED = "Passphrase expired"
   PASSPHRASE_RESET_REQUEST = "Passphrase reset request"
+  PASSPHRASE_RESET_LOADED = "Passphrase reset page loaded"
+  PASSPHRASE_RESET_FAILURE = "Passphrase reset attempt failure"
   SUCCESSFUL_PASSPHRASE_CHANGE = "Successful passphrase change"
   SUCCESSFUL_LOGIN = "Successful login"
   UNSUCCESSFUL_LOGIN = "Unsuccessful login"

--- a/test/integration/event_log_test.rb
+++ b/test/integration/event_log_test.rb
@@ -51,6 +51,22 @@ class EventLogIntegrationTest < ActionDispatch::IntegrationTest
     assert_equal EventLog::PASSPHRASE_RESET_REQUEST, @user.event_logs.first.event
   end
 
+  test "record passphrase reset page requested" do
+    token_received_in_email = @user.send_reset_password_instructions
+    visit edit_user_password_path(reset_password_token: token_received_in_email)
+
+    assert_equal EventLog::PASSPHRASE_RESET_LOADED, @user.event_logs.first.event
+  end
+
+  test "record passphrase reset failed" do
+    token_received_in_email = @user.send_reset_password_instructions
+    visit edit_user_password_path(reset_password_token: token_received_in_email)
+
+    click_on "Change my passphrase"
+
+    assert_equal EventLog::PASSPHRASE_RESET_FAILURE, @user.event_logs.first.event
+  end
+
   test "record successful passphrase change" do
     new_password = "correct horse battery daffodil"
     visit root_path


### PR DESCRIPTION
Log when a user displays a password reset page and when they fail to
reset their password. This will help us diagnose if a user is indeed
attempting to reset their password and if they are failing to reset
their password. Currently we were only getting the happy case giving us
no visibility if anything had gone wrong.