### PR TITLE
Don't allow autocompletion of passwords on the New Password fields

### DIFF
--- a/app/views/devise/passwords/_change_password_panel.html.erb
+++ b/app/views/devise/passwords/_change_password_panel.html.erb
@@ -20,7 +20,8 @@
                                :"data-weak-words" => user_email_tokens(user).join(","),
                                :"data-min-password-length" => minimum_password_length,
                                :required => true, :"aria-required" => true,
-                               :class => 'form-control input-md-5' %>
+                               :class => 'form-control input-md-5',
+                               :autocomplete => 'off' %>
           <span id="password-result-span" class="input-group-addon">
             <i id="password-result" class="glyphicon glyphicon-ok"></i>
           </span>
@@ -47,7 +48,8 @@
         <div class="input-group">
           <%= f.password_field :password_confirmation,
                                :required => true, :"aria-required" => true,
-                               :class => 'form-control input-md-5' %>
+                               :class => 'form-control input-md-5',
+                               :autocomplete => 'off' %>
           <span id="password-confirmation-result-span" class="input-group-addon">
             <i id="password-confirmation-result" class="glyphicon glyphicon-ok"></i>
           </span>


### PR DESCRIPTION
- This will help mitigate against browsers autocompleting the new
  password fields with the user's old password, leading to them not
  being able to log in the next time, ie:
  https://govuk.zendesk.com/agent/tickets/1104158.