### PR TITLE
Show the deployment instance name in the 2SV issuer

### DIFF
--- a/app/controllers/devise/two_step_verification_controller.rb
+++ b/app/controllers/devise/two_step_verification_controller.rb
@@ -23,7 +23,10 @@ class Devise::TwoStepVerificationController < Devise::TwoFactorAuthenticationCon
   end
 
   def otp_secret_key_uri
-    issuer = "#{Rails.application.config.instance_name.titleize}%20GOV.UK%20Signon"
+    issuer = "GOV.UK%20Signon"
+    if Rails.application.config.instance_name
+      issuer = "#{Rails.application.config.instance_name.titleize}%20#{issuer}"
+    end
     "otpauth://totp/#{issuer}:#{current_user.email}?secret=#{@otp_secret_key.upcase}&issuer=#{issuer}"
   end
 

--- a/app/controllers/devise/two_step_verification_controller.rb
+++ b/app/controllers/devise/two_step_verification_controller.rb
@@ -1,4 +1,7 @@
 class Devise::TwoStepVerificationController < Devise::TwoFactorAuthenticationController
+  attr_reader :otp_secret_key
+  private :otp_secret_key
+
   def new
     if current_user.otp_secret_key.present?
       redirect_to root_path, alert: "Two Step Verification is already set up"
@@ -19,14 +22,15 @@ class Devise::TwoStepVerificationController < Devise::TwoFactorAuthenticationCon
     end
   end
 
+  def otp_secret_key_uri
+    issuer = "#{Rails.application.config.instance_name.titleize}%20GOV.UK%20Signon"
+    "otpauth://totp/#{issuer}:#{current_user.email}?secret=#{@otp_secret_key.upcase}&issuer=#{issuer}"
+  end
+
   private
   def qr_code_data_uri
-    qr_code = RQRCode::QRCode.new(totp_secret_key_uri, level: :m)
+    qr_code = RQRCode::QRCode.new(otp_secret_key_uri, level: :m)
     qr_code.as_png(size: 180, fill: ChunkyPNG::Color::TRANSPARENT).to_data_url
   end
   helper_method :qr_code_data_uri
-
-  def totp_secret_key_uri
-    "otpauth://totp/GOV.UK%20Signon:#{current_user.email}?secret=#{@otp_secret_key.upcase}&issuer=GOV.UK%20Signon"
-  end
 end

--- a/config/initializers/instance_name.rb
+++ b/config/initializers/instance_name.rb
@@ -3,4 +3,8 @@
 
 # Human-friendly name for this signon instance. This is used when generating
 # reminder emails that need to disambiguate between instances.
-Rails.application.config.instance_name = nil
+if Rails.env.development? || Rails.env.test?
+  Rails.application.config.instance_name = "development"
+else
+  Rails.application.config.instance_name = nil
+end

--- a/test/controllers/batch_invitations_controller_test.rb
+++ b/test/controllers/batch_invitations_controller_test.rb
@@ -77,7 +77,7 @@ class BatchInvitationsControllerTest < ActionController::TestCase
           m.to == ["signon-alerts@digital.cabinet-office.gov.uk"]
         end
         assert_not_nil email
-        assert_equal "[SIGNON] #{@user.name} created a batch of 2 users", email.subject
+        assert_equal "[SIGNON] #{@user.name} created a batch of 2 users in development", email.subject
       end
     end
 

--- a/test/controllers/two_step_verification_controller_test.rb
+++ b/test/controllers/two_step_verification_controller_test.rb
@@ -22,7 +22,22 @@ class TwoStepVerificationControllerTest < ActionController::TestCase
     end
 
     should "include the environment titleised" do
-      assert_match %r{Development%20GOV.UK}, @controller.otp_secret_key_uri
+      assert_match %r{issuer=Development%20GOV.UK%20Signon}, @controller.otp_secret_key_uri
+    end
+
+    context "in production" do
+      setup do
+        @old_instance_name = Rails.application.config.instance_name
+        Rails.application.config.instance_name = nil
+      end
+
+      teardown do
+        Rails.application.config.instance_name = @old_instance_name
+      end
+
+      should "not include the environment name" do
+        assert_match %r{issuer=GOV.UK%20Signon}, @controller.otp_secret_key_uri
+      end
     end
 
     should "include the user's email" do

--- a/test/controllers/two_step_verification_controller_test.rb
+++ b/test/controllers/two_step_verification_controller_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+
+class TwoStepVerificationControllerTest < ActionController::TestCase
+  setup do
+    request.env["devise.mapping"] = Devise.mappings[:user]
+    @controller = Devise::TwoStepVerificationController.new
+
+    @user = create(:user)
+    sign_in @user
+  end
+
+  context "otp_secret_key_uri" do
+    setup do
+      @secret = ROTP::Base32.random_base32
+      ROTP::Base32.stubs(random_base32: @secret)
+
+      get :new
+    end
+
+    should "include the secret key uppercased" do
+      assert_match %r{#{@secret.upcase}}, @controller.otp_secret_key_uri
+    end
+
+    should "include the environment titleised" do
+      assert_match %r{Development%20GOV.UK}, @controller.otp_secret_key_uri
+    end
+
+    should "include the user's email" do
+      assert_match %r{#{@user.email}}, @controller.otp_secret_key_uri
+    end
+  end
+end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -86,7 +86,7 @@ class UsersControllerTest < ActionController::TestCase
           assert_equal "new@email.com", confirmation_email.to.first
 
           email_changed_notification = ActionMailer::Base.deliveries.last
-          assert_equal "Your GOV.UK Signon email address is being changed", email_changed_notification.subject
+          assert_equal "Your GOV.UK Signon development email address is being changed", email_changed_notification.subject
           assert_equal "old@email.com", email_changed_notification.to.first
         end
       end
@@ -571,7 +571,7 @@ class UsersControllerTest < ActionController::TestCase
             put :update, id: normal_user.id, user: { email: "new@email.com" }
 
             email_change_notifications = ActionMailer::Base.deliveries[-2..-1]
-            assert_equal ['Your GOV.UK Signon email address has been updated'], email_change_notifications.map(&:subject).uniq
+            assert_equal ['Your GOV.UK Signon development email address has been updated'], email_change_notifications.map(&:subject).uniq
             assert_equal %w(old@email.com new@email.com), email_change_notifications.map {|mail| mail.to.first }
           end
         end

--- a/test/integration/email_change_test.rb
+++ b/test/integration/email_change_test.rb
@@ -20,7 +20,7 @@ class EmailChangeTest < ActionDispatch::IntegrationTest
           admin_changes_email_address(user: user, new_email: "new@email.com")
 
           assert_equal "new@email.com", last_email.to[0]
-          assert_equal 'Your GOV.UK Signon email address has been updated', last_email.subject
+          assert_equal 'Your GOV.UK Signon development email address has been updated', last_email.subject
         end
       end
 
@@ -110,7 +110,7 @@ class EmailChangeTest < ActionDispatch::IntegrationTest
         assert_equal "new@email.com", confirmation_email.to.first
         assert_equal 'Confirm your email change', confirmation_email.subject
         assert_equal "original@email.com", notification_email.to.first
-        assert_equal 'Your GOV.UK Signon email address is being changed', notification_email.subject
+        assert_equal 'Your GOV.UK Signon development email address is being changed', notification_email.subject
       end
     end
 

--- a/test/integration/user_locking_test.rb
+++ b/test/integration/user_locking_test.rb
@@ -12,7 +12,7 @@ class UserLockingTest < ActionDispatch::IntegrationTest
       signin(user)
 
       assert_equal user.email, last_email.to[0]
-      assert_equal "Your GOV.UK Signon account has been locked", last_email.subject
+      assert_equal "Your GOV.UK Signon development account has been locked", last_email.subject
 
       assert_response_contains("Invalid email or passphrase.")
 

--- a/test/models/noisy_batch_invitation_test.rb
+++ b/test/models/noisy_batch_invitation_test.rb
@@ -10,7 +10,7 @@ class NoisyBatchInvitationTest < ActionMailer::TestCase
     end
 
     should "come from noreply-signon@" do
-      assert_equal '"GOV.UK Signon" <noreply-signon@digital.cabinet-office.gov.uk>', @email[:from].to_s
+      assert_equal '"GOV.UK Signon development" <noreply-signon-development@digital.cabinet-office.gov.uk>', @email[:from].to_s
     end
 
     should "send to noreply-signon@" do

--- a/test/models/user_mailer_test.rb
+++ b/test/models/user_mailer_test.rb
@@ -21,12 +21,12 @@ class UserMailerTest < ActionMailer::TestCase
       assert_body_includes "in 3 days"
     end
 
-    should "not include an instance name in the subject" do
-      assert_includes @email.subject, "Your GOV.UK Signon account"
+    should "include an instance name in the subject" do
+      assert_includes @email.subject, "Your GOV.UK Signon development account"
     end
 
-    should "not include an instance name in the body" do
-      assert_body_includes "Signon account, for"
+    should "include an instance name in the body" do
+      assert_body_includes "Signon development account, for"
     end
   end
 


### PR DESCRIPTION
For non-production environments, prefix "GOV.UK Signon" with the instance name in the issuer field of the QR code. This will show up in the description label in mobile Authenticator apps:

![photo 08-09-2015 10 17 08](https://cloud.githubusercontent.com/assets/18276/9731171/4c40a38e-5613-11e5-9a0c-771e9e2039bb.png)
