### PR TITLE
Improve styles of 2-step code entry and locked account pages

### DIFF
--- a/app/controllers/devise/two_step_verification_controller.rb
+++ b/app/controllers/devise/two_step_verification_controller.rb
@@ -4,7 +4,7 @@ class Devise::TwoStepVerificationController < Devise::TwoFactorAuthenticationCon
 
   def new
     if current_user.otp_secret_key.present?
-      redirect_to root_path, alert: "Two Step Verification is already set up"
+      redirect_to root_path, alert: "2-step verification is already set up"
     else
       @otp_secret_key = ROTP::Base32.random_base32
     end
@@ -15,9 +15,9 @@ class Devise::TwoStepVerificationController < Devise::TwoFactorAuthenticationCon
     totp = ROTP::TOTP.new(@otp_secret_key)
     if totp.verify(params[:code])
       current_user.update_attribute(:otp_secret_key, @otp_secret_key)
-      redirect_to "/", notice: "Two Step Verification set up"
+      redirect_to "/", notice: "2-step verification set up"
     else
-      flash.now[:alert] = "Invalid Two Step Verification code. Perhaps you entered it incorrectly?"
+      flash.now[:alert] = "Invalid 2-step verification code. Perhaps you entered it incorrectly?"
       render :new
     end
   end

--- a/app/helpers/bootstrap_flash_helper.rb
+++ b/app/helpers/bootstrap_flash_helper.rb
@@ -1,0 +1,16 @@
+module BootstrapFlashHelper
+  def bootstrap_flash_message_keys
+    [:success, :info, :warning, :danger, :error, :notice, :alert].select { |k| flash[k].present? }
+  end
+
+  def bootstrap_flash_class(flash_key)
+    case flash_key
+    when :notice
+      "success"
+    when :error, :alert
+      "danger"
+    else
+      flash_key
+    end
+  end
+end

--- a/app/views/devise/two_factor_authentication/max_login_attempts_reached.html.erb
+++ b/app/views/devise/two_factor_authentication/max_login_attempts_reached.html.erb
@@ -1,0 +1,15 @@
+<% content_for :title, "Account locked" %>
+<% content_for :thin_form, true %>
+<% content_for :suppress_navbar_items, true %>
+
+<div class="page-title">
+  <h1>Account locked</h1>
+</div>
+
+<div class="callout callout-danger">
+  <p class="lead">
+    Your account has been locked because the wrong sign on details were entered too many times.
+  </p>
+  <p>Your account will be unlocked after 1 hour.</p>
+  <p>If you need your account unlocked sooner, please contact a managing GOV.UK editor in your organisation (or your parent organisation). They can either unlock your account themselves or use the support form to get help from the GOV.UK team.</p>
+</div>

--- a/app/views/devise/two_factor_authentication/max_login_attempts_reached.html.erb
+++ b/app/views/devise/two_factor_authentication/max_login_attempts_reached.html.erb
@@ -1,15 +1,12 @@
 <% content_for :title, "Account locked" %>
 <% content_for :thin_form, true %>
-<% content_for :suppress_navbar_items, true %>
 
 <div class="page-title">
-  <h1>Account locked</h1>
+  <h1>Your account is locked</h1>
 </div>
 
 <div class="callout callout-danger">
-  <p class="lead">
-    Your account has been locked because the wrong sign on details were entered too many times.
+  <p class="lead remove-bottom-margin">
+    Your account has been locked because an incorrect 2-step verification code was entered too many times.
   </p>
-  <p>Your account will be unlocked after 1 hour.</p>
-  <p>If you need your account unlocked sooner, please contact a managing GOV.UK editor in your organisation (or your parent organisation). They can either unlock your account themselves or use the support form to get help from the GOV.UK team.</p>
 </div>

--- a/app/views/devise/two_factor_authentication/show.html.erb
+++ b/app/views/devise/two_factor_authentication/show.html.erb
@@ -1,5 +1,6 @@
 <% content_for :title, "2-step verification" %>
 <% content_for :thin_form, true %>
+<% content_for :suppress_navbar_items, true %>
 
 <div class="page-title">
   <h1>2-step verification</h1>

--- a/app/views/devise/two_factor_authentication/show.html.erb
+++ b/app/views/devise/two_factor_authentication/show.html.erb
@@ -1,0 +1,25 @@
+<% content_for :title, "2-step verification" %>
+<% content_for :thin_form, true %>
+
+<div class="page-title">
+  <h1>2-step verification</h1>
+</div>
+
+<%= form_tag([resource_name, :two_factor_authentication], :method => :put) do %>
+  <div class="panel panel-default">
+    <div class="panel-body">
+      <div class="form-group">
+        <%= label_tag :code, 'Verification code' %>
+        <p class="text-muted">Use the verification app on your phone to get your code.<br />You won’t need to do this again for 30 days.</p>
+        <%= text_field_tag :code, nil,
+          class: 'form-control input-md-4 input-lg',
+          placeholder: 'Enter 6 digit code',
+          tabindex: 1,
+          autofocus: 'autofocus' %>
+      </div>
+    </div>
+    <div class="panel-footer">
+      <%= submit_tag "Sign in", tabindex: 2, class: 'btn btn-success btn-lg btn-block' %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,24 +34,7 @@
 
 <% content_for :content do %>
   <% if content_for?(:thin_form) %><div class="thin-form"><% end %>
-  <% [:success, :info, :warning, :danger, :error, :notice, :alert].select { |k| flash[k].present? }.each do |k| %>
-    <%
-      case k
-      when :notice
-        alert_class = "success"
-      when :error, :alert
-        alert_class = "danger"
-      else
-        alert_class = k
-      end
-    %>
-    <div class="alert alert-<%= alert_class %>"
-      data-module="auto-track-event"
-      data-track-action="alert-<%= alert_class %>"
-      data-track-label="<%= strip_tags(flash[k]) %>">
-        <%= flash[k] %>
-    </div>
-  <% end %>
+  <%= render partial: 'shared/bootstrap_flash_messages' %>
   <%= yield %>
   <% if content_for?(:thin_form) %></div><% end %>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,8 +34,24 @@
 
 <% content_for :content do %>
   <% if content_for?(:thin_form) %><div class="thin-form"><% end %>
-  <%- if notice %><div class="alert alert-success" role="alert"><%= notice %></div><% end -%>
-  <%- if alert %><div class="alert alert-danger" role="alert"><%= alert %></div><% end %>
+  <% [:success, :info, :warning, :danger, :error, :notice, :alert].select { |k| flash[k].present? }.each do |k| %>
+    <%
+      case k
+      when :notice
+        alert_class = "success"
+      when :error, :alert
+        alert_class = "danger"
+      else
+        alert_class = k
+      end
+    %>
+    <div class="alert alert-<%= alert_class %>"
+      data-module="auto-track-event"
+      data-track-action="alert-<%= alert_class %>"
+      data-track-label="<%= strip_tags(flash[k]) %>">
+        <%= flash[k] %>
+    </div>
+  <% end %>
   <%= yield %>
   <% if content_for?(:thin_form) %></div><% end %>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,24 +8,24 @@
 <% end %>
 
 <% if user_signed_in? && params[:controller] !~ %r{doorkeeper/} %>
-  <% content_for :navbar_items do %>
-    <%= nav_link 'Dashboard', root_path %>
-    <% if policy(User).index? %>
-      <%= nav_link 'Users', users_path %>
-    <% end %>
-    <% if policy(ApiUser).index? %>
-      <%= nav_link 'API Users', api_users_path %>
-    <% end %>
-    <% if policy(Doorkeeper::Application).index? %>
-      <%= nav_link 'Applications', doorkeeper_applications_path %>
-    <% end %>
-    <% if policy(Organisation).index? %>
-      <%= nav_link 'Organisations', organisations_path %>
+  <% unless content_for :suppress_navbar_items %>
+    <% content_for :navbar_items do %>
+      <%= nav_link 'Dashboard', root_path %>
+      <% if policy(User).index? %>
+        <%= nav_link 'Users', users_path %>
+      <% end %>
+      <% if policy(ApiUser).index? %>
+        <%= nav_link 'API Users', api_users_path %>
+      <% end %>
+      <% if policy(Doorkeeper::Application).index? %>
+        <%= nav_link 'Applications', doorkeeper_applications_path %>
+      <% end %>
+      <% if policy(Organisation).index? %>
+        <%= nav_link 'Organisations', organisations_path %>
+      <% end %>
     <% end %>
   <% end %>
-<% end %>
 
-<% if user_signed_in? && params[:controller] !~ %r{doorkeeper/} %>
   <% content_for :navbar_right do %>
     <%= link_to current_user.name, user_link_target %>
     &bull; <%= link_to 'Sign out', destroy_user_session_path %>

--- a/app/views/shared/_bootstrap_flash_messages.html.erb
+++ b/app/views/shared/_bootstrap_flash_messages.html.erb
@@ -1,0 +1,8 @@
+<% bootstrap_flash_message_keys.each do |k| %>
+  <div class="alert alert-<%= bootstrap_flash_class(k) %>"
+    data-module="auto-track-event"
+    data-track-action="alert-<%= bootstrap_flash_class(k) %>"
+    data-track-label="<%= strip_tags(flash[k]) %>">
+      <%= flash[k] %>
+  </div>
+<% end %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -320,7 +320,8 @@ Devise.setup do |config|
                       end
 
   # Configuration for two_factor_authentication
-  config.max_login_attempts = 3
+  #FIXME: Reduce attempt limit when accounts are unlocked after an hour
+  config.max_login_attempts = 10
   config.allowed_otp_drift_seconds = 30
   config.otp_length = 6
   config.remember_otp_session_for_seconds = 30.days

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,3 +32,8 @@ en:
       taken_in_past: "was used previously. Please choose a different one."
       equal_to_current_password: "must be different than the current password."
       password_format: "must contain big, small letters and digits"
+
+  devise:
+    two_factor_authentication:
+      success: "Signed in successfully."
+      attempt_failed: "Sorry, that code didn’t work."

--- a/test/helpers/user_helpers.rb
+++ b/test/helpers/user_helpers.rb
@@ -18,7 +18,7 @@ module UserHelpers
 
     Timecop.freeze do
       fill_in :code, with: ROTP::TOTP.new(user.otp_secret_key).now
-      click_button "Submit"
+      click_button "Sign in"
     end
   end
 

--- a/test/integration/authorise_application_test.rb
+++ b/test/integration/authorise_application_test.rb
@@ -41,7 +41,7 @@ class AuthoriseApplicationTest < ActionDispatch::IntegrationTest
     ignoring_spurious_error do
       visit "/oauth/authorize?response_type=code&client_id=#{@app.uid}&redirect_uri=#{@app.redirect_uri}"
     end
-    assert_response_contains("Enter your personal code")
+    assert_response_contains("get your code")
     refute Doorkeeper::AccessGrant.find_by(resource_owner_id: @user.id)
   end
 

--- a/test/integration/sign_in_test.rb
+++ b/test/integration/sign_in_test.rb
@@ -72,7 +72,7 @@ class SignInTest < ActionDispatch::IntegrationTest
     should "prompt for a verification code" do
       visit root_path
       signin(email: "email@example.com", password: "some passphrase with various $ymb0l$")
-      assert_response_contains "Enter your personal code"
+      assert_response_contains "get your code"
       assert_selector "input[name=code]"
     end
 
@@ -80,7 +80,7 @@ class SignInTest < ActionDispatch::IntegrationTest
       visit root_path
       signin(email: "email@example.com", password: "some passphrase with various $ymb0l$")
       visit root_path
-      assert_response_contains "Enter your personal code"
+      assert_response_contains "get your code"
       assert_selector "input[name=code]"
     end
 
@@ -95,10 +95,10 @@ class SignInTest < ActionDispatch::IntegrationTest
       signin(email: "email@example.com", password: "some passphrase with various $ymb0l$")
       Timecop.freeze do
         fill_in :code, with: ""
-        click_button "Submit"
+        click_button "Sign in"
       end
 
-      assert_response_contains "Enter your personal code"
+      assert_response_contains "get your code"
     end
 
     should "prevent access with an old code" do
@@ -107,18 +107,18 @@ class SignInTest < ActionDispatch::IntegrationTest
       visit root_path
       signin(email: "email@example.com", password: "some passphrase with various $ymb0l$")
       fill_in :code, with: old_code
-      click_button "Submit"
+      click_button "Sign in"
 
-      assert_response_contains "Enter your personal code"
+      assert_response_contains "get your code"
     end
 
     should "prevent access with a garbage code" do
       visit root_path
       signin(email: "email@example.com", password: "some passphrase with various $ymb0l$")
       fill_in :code, with: "abcdef"
-      click_button "Submit"
+      click_button "Sign in"
 
-      assert_response_contains "Enter your personal code"
+      assert_response_contains "get your code"
     end
   end
 end

--- a/test/integration/two_step_verification_test.rb
+++ b/test/integration/two_step_verification_test.rb
@@ -13,7 +13,7 @@ class TwoStepVerificationTest < ActionDispatch::IntegrationTest
       end
 
       should "redirect to homepage" do
-        assert_response_contains "Two Step Verification is already set up"
+        assert_response_contains "2-step verification is already set up"
         assert_response_contains "Welcome to GOV.UK"
       end
     end
@@ -39,7 +39,7 @@ class TwoStepVerificationTest < ActionDispatch::IntegrationTest
         end
 
         should "reject the code" do
-          assert_response_contains "Invalid Two Step Verification code. Perhaps you entered it incorrectly?"
+          assert_response_contains "Invalid 2-step verification code. Perhaps you entered it incorrectly?"
         end
 
         should "show the same secret" do
@@ -56,7 +56,7 @@ class TwoStepVerificationTest < ActionDispatch::IntegrationTest
         end
 
         should "accept the code" do
-          assert_response_contains "Two Step Verification set up"
+          assert_response_contains "2-step verification set up"
         end
 
         should "persist the confirmed secret" do


### PR DESCRIPTION
* Tweak copy to use 2-step consistently
* Override default 2-step verification form and max requests views
* Increase max login attempt to 10 for now
* Display `flash[:error]` messages from the two_factor_authentication gem
* Track all flash messages in analytics to see how often error states happen

https://trello.com/c/eAU9Z46p/90-front-end-work-for-mvp-2sv-medium

<img width="632" alt="screen shot 2015-09-09 at 16 16 02" src="https://cloud.githubusercontent.com/assets/319055/9765900/536ea43e-570e-11e5-9d3e-a878c00b132a.png">

<img width="637" alt="screen shot 2015-09-09 at 16 16 16" src="https://cloud.githubusercontent.com/assets/319055/9765923/6a4af4f0-570e-11e5-8507-f2f607b0eb1b.png">
