### PR TITLE
Speed up slow user export functionality

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -132,7 +132,7 @@ class UsersController < ApplicationController
     @users = @users.filter(params[:filter]) if params[:filter].present?
     @users = @users.with_role(params[:role]) if can_filter_role?
     @users = @users.with_organisation(params[:organisation]) if params[:organisation].present?
-    @users = @users.select {|u| u.status == params[:status] } if params[:status].present?
+    @users = @users.with_status(params[:status]) if params[:status].present?
   end
 
   def can_filter_role?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -178,8 +178,9 @@ class UsersController < ApplicationController
     applications = Doorkeeper::Application.includes(:supported_permissions)
     CSV.generate do |csv|
       csv << UserExportPresenter.header_row(applications)
+      presenter = UserExportPresenter.new(applications)
       @users.each do |user|
-        csv << UserExportPresenter.new(user, applications).row
+        csv << presenter.row(user)
       end
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -177,8 +177,8 @@ class UsersController < ApplicationController
   def export
     applications = Doorkeeper::Application.all
     CSV.generate do |csv|
-      csv << UserExportPresenter.header_row(applications)
       presenter = UserExportPresenter.new(applications)
+      csv << presenter.header_row
       @users.includes(:organisation).find_each do |user|
         csv << presenter.row(user)
       end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -175,11 +175,11 @@ class UsersController < ApplicationController
   end
 
   def export
-    applications = Doorkeeper::Application.includes(:supported_permissions)
+    applications = Doorkeeper::Application.all
     CSV.generate do |csv|
       csv << UserExportPresenter.header_row(applications)
       presenter = UserExportPresenter.new(applications)
-      @users.each do |user|
+      @users.includes(:organisation).find_each do |user|
         csv << presenter.row(user)
       end
     end

--- a/app/presenters/user_export_presenter.rb
+++ b/app/presenters/user_export_presenter.rb
@@ -14,7 +14,7 @@ class UserExportPresenter
     end
   end
 
-  def self.header_row(applications)
+  def header_row
     [
       'Name',
       'Email',

--- a/app/presenters/user_export_presenter.rb
+++ b/app/presenters/user_export_presenter.rb
@@ -1,8 +1,7 @@
 class UserExportPresenter
-  attr_accessor :user, :applications
+  attr_accessor :applications
 
-  def initialize(user, applications)
-    @user = user
+  def initialize(applications)
     @applications = applications
   end
 
@@ -19,7 +18,7 @@ class UserExportPresenter
     ].concat applications.map &:name
   end
 
-  def row
+  def row(user)
     [
       user.name,
       user.email,
@@ -29,10 +28,10 @@ class UserExportPresenter
       user.current_sign_in_at.try(:to_formatted_s, :db),
       user.created_at.try(:to_formatted_s, :db),
       user.status.humanize,
-    ].concat(app_permissions)
+    ].concat(app_permissions(user))
   end
 
-  def app_permissions
+  def app_permissions(user)
     applications.map do |application|
       perms = user.permissions_for(application)
       perms.sort.join(', ') if perms.any?

--- a/app/presenters/user_export_presenter.rb
+++ b/app/presenters/user_export_presenter.rb
@@ -1,8 +1,17 @@
 class UserExportPresenter
-  attr_accessor :applications
+  attr_reader :applications, :app_permissions
 
   def initialize(applications)
     @applications = applications
+
+    permission_names = Hash[SupportedPermission.pluck(:id, :name)]
+
+    @app_permissions = {}
+    UserApplicationPermission.find_each do |permission|
+      @app_permissions[permission.user_id] ||= {}
+      @app_permissions[permission.user_id][permission.application_id] ||= []
+      @app_permissions[permission.user_id][permission.application_id] << permission_names[permission.supported_permission_id]
+    end
   end
 
   def self.header_row(applications)
@@ -28,13 +37,13 @@ class UserExportPresenter
       user.current_sign_in_at.try(:to_formatted_s, :db),
       user.created_at.try(:to_formatted_s, :db),
       user.status.humanize,
-    ].concat(app_permissions(user))
+    ].concat(app_permissions_for(user))
   end
 
-  def app_permissions(user)
+  def app_permissions_for(user)
     applications.map do |application|
-      perms = user.permissions_for(application)
-      perms.sort.join(', ') if perms.any?
+      perms = app_permissions[user.id][application.id] if app_permissions[user.id]
+      perms.sort.join(', ') if perms
     end
   end
 end

--- a/lib/devise/models/password_expirable.rb
+++ b/lib/devise/models/password_expirable.rb
@@ -11,10 +11,23 @@ module Devise
 
       included do
         before_save :update_password_changed
+
+        scope :with_need_change_password, -> do
+          if password_expires?
+            where(arel_table[:password_changed_at].eq(nil).
+              or(arel_table[:password_changed_at].lt(self.expire_password_after.ago)))
+          end
+        end
+
+        scope :without_need_change_password, -> do
+          if password_expires?
+            where(arel_table[:password_changed_at].gteq(self.expire_password_after.ago))
+          end
+        end
       end
 
       def need_change_password?
-        if self.expire_password_after.is_a?(Fixnum) || self.expire_password_after.is_a?(Float)
+        if self.class.password_expires?
           self.password_changed_at.nil? || self.password_changed_at < self.expire_password_after.ago
         else
           false
@@ -33,6 +46,10 @@ module Devise
 
       module ClassMethods
         ::Devise::Models.config(self, :expire_password_after)
+
+        def password_expires?
+          self.expire_password_after.is_a?(Fixnum) || self.expire_password_after.is_a?(Float)
+        end
       end
     end
   end

--- a/test/models/user_export_presenter_test.rb
+++ b/test/models/user_export_presenter_test.rb
@@ -25,14 +25,14 @@ class UserExportPresenterTest < ActiveSupport::TestCase
     @user.grant_application_permissions(@apps[0], ["editor"])
     @user.grant_application_permissions(@apps[2], %w(editor admin))
 
-    perms = UserExportPresenter.new(@user, @apps).app_permissions
+    perms = UserExportPresenter.new(@apps).app_permissions(@user)
 
     expected = ["editor", nil, "admin, editor", nil, nil]
     assert_equal(expected, perms)
   end
 
   should "output user details" do
-    row = UserExportPresenter.new(@user, []).row
+    row = UserExportPresenter.new([]).row(@user)
     expected = [
       'Test User', 'test@dept.gov.uk', 'Normal', nil, 0, nil, '2015-01-15 09:00:00', 'Active'
     ]

--- a/test/models/user_export_presenter_test.rb
+++ b/test/models/user_export_presenter_test.rb
@@ -25,7 +25,7 @@ class UserExportPresenterTest < ActiveSupport::TestCase
     @user.grant_application_permissions(@apps[0], ["editor"])
     @user.grant_application_permissions(@apps[2], %w(editor admin))
 
-    perms = UserExportPresenter.new(@apps).app_permissions(@user)
+    perms = UserExportPresenter.new(@apps).app_permissions_for(@user)
 
     expected = ["editor", nil, "admin, editor", nil, nil]
     assert_equal(expected, perms)

--- a/test/models/user_export_presenter_test.rb
+++ b/test/models/user_export_presenter_test.rb
@@ -12,7 +12,7 @@ class UserExportPresenterTest < ActiveSupport::TestCase
 
 
   should "output header row including application names" do
-    header_row = UserExportPresenter.header_row(@apps)
+    header_row = UserExportPresenter.new(@apps).header_row
 
     expected = [
       'Name', 'Email', 'Role', 'Organisation', 'Sign-in count', 'Last sign-in',

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -259,31 +259,62 @@ class UserTest < ActiveSupport::TestCase
 
   context "User status" do
     setup do
-      @user = create(:user)
+      @locked = create(:user)
+      @locked.lock_access!
+      @suspended = create(:user)
+      @suspended.suspend("because grumble")
+      @invited = User.invite!(name: "Oberyn Martell", email: "redviper@dorne.com")
+      @expired = create(:user, password_changed_at: 91.days.ago)
     end
 
-    should "return suspended" do
-      @user.suspend("because grumble")
-      assert_equal "suspended", @user.status
+    context "filtering" do
+      should "be able to filter by all statuses" do
+        User::USER_STATUSES.each do |status|
+          assert_not_empty User.with_status(status)
+        end
+      end
+
+      should "filter suspended" do
+        assert_equal [@suspended], User.with_status(User::USER_STATUS_SUSPENDED).all
+      end
+
+      should "filter invited" do
+        assert_equal [@invited], User.with_status(User::USER_STATUS_INVITED).all
+      end
+
+      should "filter passphrase expired" do
+        assert_equal [@expired], User.with_status(User::USER_STATUS_PASSPHRASE_EXPIRED).all
+      end
+
+      should "filter locked" do
+        assert_equal [@locked], User.with_status(User::USER_STATUS_LOCKED).all
+      end
+
+      should "filter active" do
+        assert_equal [@user], User.with_status(User::USER_STATUS_ACTIVE).all
+      end
     end
 
-    should "return invited" do
-      user = User.invite!(name: "Oberyn Martell", email: "redviper@dorne.com")
-      assert_equal "invited", user.status
-    end
+    context "detecting" do
+      should "detect suspended" do
+        assert_equal "suspended", @suspended.status
+      end
 
-    should "return passphrase expired" do
-      user = create(:user, password_changed_at: 91.days.ago)
-      assert_equal "passphrase expired", user.status
-    end
+      should "detect invited" do
+        assert_equal "invited", @invited.status
+      end
 
-    should "return locked" do
-      @user.lock_access!
-      assert_equal "locked", @user.status
-    end
+      should "detect passphrase expired" do
+        assert_equal "passphrase expired", @expired.status
+      end
 
-    should "return active" do
-      assert_equal "active", @user.status
+      should "detect locked" do
+        assert_equal "locked", @locked.status
+      end
+
+      should "detect active" do
+        assert_equal "active", @user.status
+      end
     end
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -207,6 +207,16 @@ class UserTest < ActiveSupport::TestCase
     assert_user_has_permissions ['signin'], app, user
   end
 
+  test "returns multiple permissions in name order" do
+    app = create(:application, name: "my_app", with_supported_permissions: ["edit"])
+    user = create(:user)
+
+    user.grant_application_permission(app, "signin")
+    user.grant_application_permission(app, "edit")
+
+    assert_user_has_permissions %w(edit signin), app, user
+  end
+
   test "inviting a user sets confirmed_at" do
     if user = User.find_by_email("j@1.com")
       user.delete


### PR DESCRIPTION
Trello: https://trello.com/c/AbFXHJ5u/104-504-timeout-when-trying-to-download-a-csv-of-signon-users-medium

The "Export as CSV" button in signon will generally result in a 504 in production due to it taking over 15 seconds to generate the CSV (actually around 10 minutes on a VM). This is mostly avoidable by fetching data in more optimised ways rather than relying on ActiveRecord's association magic.

CSVs with no filtering are now returned in around 4 seconds on a VM, which should be quick enough.

This pull request best reviewed commit by commit.

Possible future refactoring would be to pass a scope of users into the presenter and have it generate the CSV itself.