### PR TITLE
Revert "Don't automatically log users in after password reset"

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -193,9 +193,6 @@ Devise.setup do |config|
   # change their passwords.
   config.reset_password_within = 6.hours
 
-  # Don't automatically sign a user in once they've reset their password
-  config.sign_in_after_reset_password = false
-
   # ==> Configuration for :encryptable
   # Allow you to use another encryption algorithm besides bcrypt (default). You can use
   # :sha1, :sha512 or encryptors from others authentication tools as :clearance_sha1,

--- a/test/integration/passphrase_reset_test.rb
+++ b/test/integration/passphrase_reset_test.rb
@@ -109,20 +109,4 @@ class PassphraseResetTest < ActionDispatch::IntegrationTest
     click_link 'Forgot your passphrase?'
     assert_response_contains("Request a passphrase reset")
   end
-
-  should "ask for 2SV if the user has a secret key set" do
-    perform_enqueued_jobs do
-      secret = ROTP::Base32.random_base32
-      user = create(:user, otp_secret_key: secret)
-
-      new_password = "some v3ry s3cure passphrase"
-
-      trigger_reset_for(user.email)
-      open_email(user.email)
-      complete_password_reset(current_email, new_password: new_password)
-
-      visit new_user_session_path
-      signin_with_2sv(email: user.email, password: new_password)
-    end
-  end
 end


### PR DESCRIPTION
This reverts commit 41c1e1edf410f46b8239bf89e9c3156a974c33b2 as per https://trello.com/c/0WvaVtE6/109-undo-adding-sign-in-screen-after-successful-passphrase-reset.

This is being reverted because as part of the wider 2SV story, we will be requiring 2SV for users before they can reset their password. Thus, forcing them to be logged out on a successful password reset would mean they'd have to enter a 2SV code twice.

/cc @fofr