### PR TITLE
Add 2SV session memory

### DIFF
--- a/app/controllers/devise/two_step_verification_controller.rb
+++ b/app/controllers/devise/two_step_verification_controller.rb
@@ -15,7 +15,7 @@ class Devise::TwoStepVerificationController < DeviseController
       expires_seconds = User::REMEMBER_2SV_SESSION_FOR
       if expires_seconds && expires_seconds > 0
         cookies.signed['remember_2sv_session'] = {
-          value: {user_id: current_user.id, expires: expires_seconds.from_now},
+          value: {user_id: current_user.id, valid_until: expires_seconds.from_now},
           expires: expires_seconds.from_now
         }
       end

--- a/app/controllers/devise/two_step_verification_controller.rb
+++ b/app/controllers/devise/two_step_verification_controller.rb
@@ -12,6 +12,13 @@ class Devise::TwoStepVerificationController < DeviseController
     render(:show) && return if params[:code].nil?
 
     if current_user.authenticate_otp(params[:code])
+      expires_seconds = User::REMEMBER_2SV_SESSION_FOR
+      if expires_seconds && expires_seconds > 0
+        cookies.signed['remember_2sv_session'] = {
+          value: {user_id: current_user.id, expires: expires_seconds.from_now},
+          expires: expires_seconds.from_now
+        }
+      end
       warden.session(:user)['need_two_step_verification'] = false
       sign_in :user, current_user, bypass: true
       set_flash_message :notice, :success

--- a/lib/devise/hooks/two_step_verification.rb
+++ b/lib/devise/hooks/two_step_verification.rb
@@ -1,5 +1,8 @@
 Warden::Manager.after_authentication do |user, auth, _options|
   if user.respond_to?(:need_two_step_verification?)
-    auth.session(:user)['need_two_step_verification'] = user.need_two_step_verification?
+    cookie = auth.env["action_dispatch.cookies"].signed["remember_2sv_session"]
+    unless cookie && cookie[:user_id] == user.id && cookie[:expires] > Time.now
+      auth.session(:user)['need_two_step_verification'] = user.need_two_step_verification?
+    end
   end
 end

--- a/lib/devise/hooks/two_step_verification.rb
+++ b/lib/devise/hooks/two_step_verification.rb
@@ -1,7 +1,7 @@
 Warden::Manager.after_authentication do |user, auth, _options|
   if user.respond_to?(:need_two_step_verification?)
     cookie = auth.env["action_dispatch.cookies"].signed["remember_2sv_session"]
-    unless cookie && cookie[:user_id] == user.id && cookie[:expires] > Time.now
+    unless cookie && cookie[:user_id] == user.id && cookie[:valid_until] > Time.now
       auth.session(:user)['need_two_step_verification'] = user.need_two_step_verification?
     end
   end

--- a/test/integration/sign_in_test.rb
+++ b/test/integration/sign_in_test.rb
@@ -76,6 +76,27 @@ class SignInTest < ActionDispatch::IntegrationTest
       assert_selector "input[name=code]"
     end
 
+    should "not prompt for a verification code twice per browser in 30 days" do
+      visit root_path
+      signin_with_2sv(email: "email@example.com", password: "some passphrase with various $ymb0l$")
+      assert_response_contains "Welcome to GOV.UK"
+
+      signout
+      visit root_path
+
+      signin(email: "email@example.com", password: "some passphrase with various $ymb0l$")
+      assert_response_contains "Welcome to GOV.UK"
+
+      signout
+      visit root_path
+
+      Timecop.travel(30.days.from_now + 1) do
+        visit root_path
+        signin_with_2sv(email: "email@example.com", password: "some passphrase with various $ymb0l$")
+        assert_response_contains "Welcome to GOV.UK"
+      end
+    end
+
     should "prevent access to signon until fully authenticated" do
       visit root_path
       signin(email: "email@example.com", password: "some passphrase with various $ymb0l$")


### PR DESCRIPTION
This was missed in the removal of the two_factor_authentication gem
from this repo.

This also improves upon the security of the original implementation by
verifying user id and expiration, making it impossible to copy the
value of the signed gem and re-use it later, extend the expiration
period, or use your cookie for another user.

/cc @jamiecobbett 