### PR TITLE
Don't load simplecov unnecessarily

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,4 +1,0 @@
-require 'simplecov-rcov'
-
-SimpleCov.start 'rails'
-SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter

--- a/Gemfile
+++ b/Gemfile
@@ -67,8 +67,8 @@ group :test do
   gem 'mocha', '1.1.0', require: false
   gem 'webmock', '1.17.3'
   gem 'minitest', '5.1.0'
-  gem 'simplecov', '0.6.4'
-  gem 'simplecov-rcov', '0.2.3'
+  gem 'simplecov', '0.6.4', require: false
+  gem 'simplecov-rcov', '0.2.3', require: false
   gem 'ci_reporter', '1.7.0'
   gem 'timecop', '0.7.1'
   gem 'shoulda-context', '1.2.1', require: false

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,13 @@
 ENV["RAILS_ENV"] = "test"
+
+if ENV["USE_SIMPLECOV"]
+  require 'simplecov'
+  require 'simplecov-rcov'
+
+  SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
+  SimpleCov.start 'rails'
+end
+
 require File.expand_path('../../config/environment', __FILE__)
 
 require 'rails/test_help'


### PR DESCRIPTION
SimpleCov was running and producing coverage reports when I ran `rake`
in the development environment, which isn't good. Also, it wasn't
really configured properly for CI either.

The question is, does anyone care about coverage? If yes, merge this.

If no, I'll just blow it all away and forget it ever happened :boom: