### PR TITLE
Flag for 2SV

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem 'rails', '4.2.4'
 
 gem 'kaminari', '~> 0.16.3'
 gem 'bootstrap-kaminari-views', '0.0.5'
+
 gem 'alphabetical_paginate', '2.2.3'
 gem 'mysql2', '0.3.20'
 gem 'govuk_admin_template', '3.0.0'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,7 +17,7 @@ class ApplicationController < ActionController::Base
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
   def after_sign_in_path_for(resource)
-    if resource.require_2sv?
+    if resource.prompt_for_2sv?
       prompt_two_step_verification_path
     else
       super

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,6 +16,14 @@ class ApplicationController < ActionController::Base
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
+  def after_sign_in_path_for(resource)
+    if resource.require_2sv?
+      prompt_two_step_verification_path
+    else
+      super
+    end
+  end
+
   def after_sign_out_path_for(resource_or_scope)
     new_user_session_path
   end

--- a/app/controllers/devise/two_step_verification_controller.rb
+++ b/app/controllers/devise/two_step_verification_controller.rb
@@ -54,7 +54,10 @@ class Devise::TwoStepVerificationController < DeviseController
     @otp_secret_key = params[:otp_secret_key]
     totp = ROTP::TOTP.new(@otp_secret_key)
     if totp.verify(params[:code])
-      current_user.update_attribute(:otp_secret_key, @otp_secret_key)
+      current_user.update_attributes(
+        otp_secret_key: @otp_secret_key,
+        require_2sv: false
+      )
       EventLog.record_event(current_user, EventLog::TWO_STEP_ENABLED)
       redirect_to "/", notice: "2-step verification set up"
     else

--- a/app/controllers/devise/two_step_verification_controller.rb
+++ b/app/controllers/devise/two_step_verification_controller.rb
@@ -1,11 +1,16 @@
 class Devise::TwoStepVerificationController < DeviseController
-  before_filter :prepare_and_validate, except: :prompt
+  before_filter :prepare_and_validate, except: [:prompt, :defer]
   skip_before_filter :handle_two_step_verification
 
   attr_reader :otp_secret_key
   private :otp_secret_key
 
   def prompt
+  end
+
+  def defer
+    current_user.defer_two_step_verification
+    redirect_to root_path, notice: 'You will not be required to setup 2-step verification.'
   end
 
   def show

--- a/app/controllers/devise/two_step_verification_controller.rb
+++ b/app/controllers/devise/two_step_verification_controller.rb
@@ -55,10 +55,7 @@ class Devise::TwoStepVerificationController < DeviseController
     @otp_secret_key = params[:otp_secret_key]
     totp = ROTP::TOTP.new(@otp_secret_key)
     if totp.verify(params[:code])
-      current_user.update_attributes(
-        otp_secret_key: @otp_secret_key,
-        require_2sv: false
-      )
+      current_user.update_attribute(:otp_secret_key, @otp_secret_key)
       EventLog.record_event(current_user, EventLog::TWO_STEP_ENABLED)
       redirect_to_prior_flow(notice: "2-step verification set up")
     else

--- a/app/controllers/devise/two_step_verification_controller.rb
+++ b/app/controllers/devise/two_step_verification_controller.rb
@@ -10,7 +10,7 @@ class Devise::TwoStepVerificationController < DeviseController
 
   def defer
     current_user.defer_two_step_verification
-    redirect_to root_path, notice: 'You will not be required to setup 2-step verification.'
+    redirect_to stored_location_for(:user) || :root
   end
 
   def show

--- a/app/controllers/devise/two_step_verification_controller.rb
+++ b/app/controllers/devise/two_step_verification_controller.rb
@@ -1,9 +1,12 @@
 class Devise::TwoStepVerificationController < DeviseController
-  before_filter :prepare_and_validate
+  before_filter :prepare_and_validate, except: :prompt
   skip_before_filter :handle_two_step_verification
 
   attr_reader :otp_secret_key
   private :otp_secret_key
+
+  def prompt
+  end
 
   def show
   end

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -22,6 +22,11 @@ class PasswordsController < Devise::PasswordsController
     end
   end
 
+  protected
+  def after_resetting_password_path_for(resource)
+    signed_in_root_path(resource)
+  end
+
 private
   def record_password_reset_request
     user_from_params = User.find_by_email(params[:user][:email]) if params[:user].present?

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,6 +6,11 @@ class SessionsController < Devise::SessionsController
     super
   end
 
+  def new
+    store_location_for(:user, request.referer) if request.get?
+    super
+  end
+
   def create
     log_event
     super

--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -25,6 +25,7 @@ class EventLog < ActiveRecord::Base
   TWO_STEP_VERIFIED = "2-step verification successful"
   TWO_STEP_VERIFICATION_FAILED = "2-step verification failed"
   TWO_STEP_LOCKED = "2-step verification failed too many times, account locked for #{LOCKED_DURATION}"
+  TWO_STEP_PROMPT_DEFERRED = "2-step prompt deferred"
 
   # API users
   API_USER_CREATED = "Account created"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -80,6 +80,11 @@ class User < ActiveRecord::Base
     end
   }
 
+  def defer_two_step_verification
+    self.update_attribute(:require_2sv, false)
+    EventLog.record_event(self, EventLog::TWO_STEP_PROMPT_DEFERRED)
+  end
+
   def event_logs
     EventLog.where(uid: uid).order(created_at: :desc)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -84,7 +84,13 @@ class User < ActiveRecord::Base
   }
 
   def require_2sv?
-    otp_secret_key.present? ? false : super
+    return false if otp_secret_key.present?
+
+    if deferred_2sv_at?
+      deferred_2sv_at < 24.hours.ago
+    else
+      super
+    end
   end
 
   def defer_two_step_verification

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -83,6 +83,10 @@ class User < ActiveRecord::Base
     end
   }
 
+  def require_2sv?
+    otp_secret_key.present? ? false : super
+  end
+
   def defer_two_step_verification
     self.update_attribute(:require_2sv, false)
     EventLog.record_event(self, EventLog::TWO_STEP_PROMPT_DEFERRED)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,9 +35,6 @@ class User < ActiveRecord::Base
          :password_archivable, # in signonotron2/lib/devise/models/password_archivable.rb
          :password_expirable   # in signonotron2/lib/devise/models/password_expirable.rb
 
-  validates :require_2sv,
-    inclusion: { in: [false], message: 'This user is already enrolled in 2SV' },
-    if: ->(u) { u.otp_secret_key.present? }
   validates :name, presence: true
   validates :reason_for_suspension, presence: true, if: proc { |u| u.suspended? }
   validate :organisation_admin_belongs_to_organisation

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,7 +35,9 @@ class User < ActiveRecord::Base
          :password_archivable, # in signonotron2/lib/devise/models/password_archivable.rb
          :password_expirable   # in signonotron2/lib/devise/models/password_expirable.rb
 
-  validates :require_2sv, inclusion: [false], if: ->(u) { u.otp_secret_key.present? }
+  validates :require_2sv,
+    inclusion: { in: [false], message: 'This user is already enrolled in 2SV' },
+    if: ->(u) { u.otp_secret_key.present? }
   validates :name, presence: true
   validates :reason_for_suspension, presence: true, if: proc { |u| u.suspended? }
   validate :organisation_admin_belongs_to_organisation

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -92,9 +92,7 @@ class User < ActiveRecord::Base
 
   def defer_two_step_verification
     transaction do
-      self.require_2sv = false
-      self.deferred_2sv_at = Time.zone.now
-      self.save!
+      touch(:deferred_2sv_at)
 
       EventLog.record_event(self, EventLog::TWO_STEP_PROMPT_DEFERRED)
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,6 +35,7 @@ class User < ActiveRecord::Base
          :password_archivable, # in signonotron2/lib/devise/models/password_archivable.rb
          :password_expirable   # in signonotron2/lib/devise/models/password_expirable.rb
 
+  validates :require_2sv, inclusion: [false], if: ->(u) { u.otp_secret_key.present? }
   validates :name, presence: true
   validates :reason_for_suspension, presence: true, if: proc { |u| u.suspended? }
   validate :organisation_admin_belongs_to_organisation

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -80,13 +80,13 @@ class User < ActiveRecord::Base
     end
   }
 
-  def require_2sv?
+  def prompt_for_2sv?
     return false if otp_secret_key.present?
 
     if deferred_2sv_at?
       deferred_2sv_at < 24.hours.ago
     else
-      super
+      read_attribute(:require_2sv)
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -88,8 +88,13 @@ class User < ActiveRecord::Base
   end
 
   def defer_two_step_verification
-    self.update_attribute(:require_2sv, false)
-    EventLog.record_event(self, EventLog::TWO_STEP_PROMPT_DEFERRED)
+    transaction do
+      self.require_2sv = false
+      self.deferred_2sv_at = Time.zone.now
+      self.save!
+
+      EventLog.record_event(self, EventLog::TWO_STEP_PROMPT_DEFERRED)
+    end
   end
 
   def event_logs

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -52,6 +52,10 @@ class UserPolicy < BasePolicy
     current_user.superadmin?
   end
 
+  def flag_2sv?
+    current_user.superadmin?
+  end
+
   class Scope < ::BasePolicy::Scope
     def resolve
       if current_user.superadmin?

--- a/app/views/devise/two_step_verification/prompt.html.erb
+++ b/app/views/devise/two_step_verification/prompt.html.erb
@@ -12,7 +12,7 @@
     <p>Setup takes about five minutes.</p>
   </div>
   <div class="panel-footer">
-    <%= link_to 'Setup now', '#', class: 'btn btn-success btn-lg' %>
+    <%= link_to 'Setup now', new_two_step_verification_path, class: 'btn btn-success btn-lg' %>
     <%= button_to 'Continue and setup later', defer_two_step_verification_path, class: 'btn btn-default btn-lg pull-right' %>
   </div>
 </div>

--- a/app/views/devise/two_step_verification/prompt.html.erb
+++ b/app/views/devise/two_step_verification/prompt.html.erb
@@ -1,0 +1,19 @@
+<% content_for :title, "Setup 2-step verification?" %>
+<% content_for :thin_form, true %>
+<% content_for :suppress_navbar_items, true %>
+
+<div class="page-title">
+  <h1>Setup 2-step verification?</h1>
+</div>
+
+<div class="panel panel-default">
+  <div class="panel-body">
+    <p>From DATE you will need to use two step verification.</p>
+    <p>Two step verification adds another layer of security to your account. You'll need to use an app on your phone to enter a security code before you can sign in.</p>
+    <p>Setup takes about five minutes.</p>
+  </div>
+  <div class="panel-footer">
+    <%= link_to 'Setup now', '#', class: 'btn btn-success btn-lg' %>
+    <%= link_to 'Continue and setup later', '#', class: 'btn btn-default btn-lg pull-right' %>
+  </div>
+</div>

--- a/app/views/devise/two_step_verification/prompt.html.erb
+++ b/app/views/devise/two_step_verification/prompt.html.erb
@@ -8,12 +8,11 @@
 
 <div class="panel panel-default">
   <div class="panel-body">
-    <p>From DATE you will need to use two step verification.</p>
     <p>Two step verification adds another layer of security to your account. You'll need to use an app on your phone to enter a security code before you can sign in.</p>
     <p>Setup takes about five minutes.</p>
   </div>
   <div class="panel-footer">
     <%= link_to 'Setup now', '#', class: 'btn btn-success btn-lg' %>
-    <%= link_to 'Continue and setup later', '#', class: 'btn btn-default btn-lg pull-right' %>
+    <%= button_to 'Continue and setup later', defer_two_step_verification_path, class: 'btn btn-default btn-lg pull-right' %>
   </div>
 </div>

--- a/app/views/devise/two_step_verification/prompt.html.erb
+++ b/app/views/devise/two_step_verification/prompt.html.erb
@@ -6,6 +6,7 @@
   <h1>Setup 2-step verification?</h1>
 </div>
 
+<%= form_tag defer_two_step_verification_path, method: :put do %>
 <div class="panel panel-default">
   <div class="panel-body">
     <p>Two step verification adds another layer of security to your account. You'll need to use an app on your phone to enter a security code before you can sign in.</p>
@@ -13,6 +14,7 @@
   </div>
   <div class="panel-footer">
     <%= link_to 'Setup now', new_two_step_verification_path, class: 'btn btn-success btn-lg' %>
-    <%= button_to 'Continue and setup later', defer_two_step_verification_path, class: 'btn btn-default btn-lg pull-right' %>
+    <%= submit_tag 'Continue and setup later', class: 'btn btn-default btn-lg pull-right' %>
   </div>
 </div>
+<% end %>

--- a/app/views/devise/two_step_verification/prompt.html.erb
+++ b/app/views/devise/two_step_verification/prompt.html.erb
@@ -1,20 +1,21 @@
-<% content_for :title, "Setup 2-step verification?" %>
+<% content_for :title, "Make your account more secure" %>
 <% content_for :thin_form, true %>
 <% content_for :suppress_navbar_items, true %>
 
 <div class="page-title">
-  <h1>Setup 2-step verification?</h1>
+  <h1>Make your account more secure</h1>
 </div>
 
 <%= form_tag defer_two_step_verification_path, method: :put do %>
 <div class="panel panel-default">
   <div class="panel-body">
-    <p>Two step verification adds another layer of security to your account. You'll need to use an app on your phone to enter a security code before you can sign in.</p>
-    <p>Setup takes about five minutes.</p>
+    <p class="lead">Make your signon account more secure by setting up 2-step verification. You’ll need to install an app on your phone which will generate a security code to enter when you sign in.</p>
+    <p class="lead">From Tuesday 30 October 2-step verification will be mandatory.</p>
+    <p class="lead remove-bottom-margin">Set up takes about 5 minutes.</p>
   </div>
   <div class="panel-footer">
-    <%= link_to 'Setup now', new_two_step_verification_path, class: 'btn btn-success btn-lg' %>
-    <%= submit_tag 'Continue and setup later', class: 'btn btn-default btn-lg pull-right' %>
+    <%= link_to 'Start set up', new_two_step_verification_path, class: 'btn btn-success btn-lg' %>
+    <%= submit_tag 'Not now', class: 'btn btn-default btn-lg pull-right' %>
   </div>
 </div>
 <% end %>

--- a/app/views/users/_form_fields.html.erb
+++ b/app/views/users/_form_fields.html.erb
@@ -41,6 +41,10 @@
   <%= f.select :organisation_id, organisation_options(f), organisation_select_options, { class: "chosen-select form-control", 'data-module' => 'chosen' } %>
 </p>
 
+<p class="form-group">
+  <%= f.check_box :requires_2sv %> <%= f.label :requires_2sv, "Requires 2SV" %>
+</p>
+
 <h2 class="add-vertical-margins">Permissions</h2>
 
 <%= render partial: "shared/user_permissions", locals: { user_object: f.object }%>

--- a/app/views/users/_form_fields.html.erb
+++ b/app/views/users/_form_fields.html.erb
@@ -38,8 +38,8 @@
 
 <% if policy(User).flag_2sv? %>
   <p class="checkbox">
-    <%= f.label :requires_2sv do %>
-      <%= f.check_box :requires_2sv %> Require 2-step verification
+    <%= f.label :require_2sv do %>
+      <%= f.check_box :require_2sv %> Require 2-step verification
     <% end %>
   </p>
 <% end %>

--- a/app/views/users/_form_fields.html.erb
+++ b/app/views/users/_form_fields.html.erb
@@ -41,9 +41,11 @@
   <%= f.select :organisation_id, organisation_options(f), organisation_select_options, { class: "chosen-select form-control", 'data-module' => 'chosen' } %>
 </p>
 
-<p class="form-group">
-  <%= f.check_box :requires_2sv %> <%= f.label :requires_2sv, "Requires 2SV" %>
-</p>
+<% if policy(User).flag_2sv? %>
+  <p class="form-group">
+    <%= f.check_box :requires_2sv %> <%= f.label :requires_2sv, "Requires 2SV" %>
+  </p>
+<% end %>
 
 <h2 class="add-vertical-margins">Permissions</h2>
 

--- a/app/views/users/_form_fields.html.erb
+++ b/app/views/users/_form_fields.html.erb
@@ -43,7 +43,7 @@
 
 <% if policy(User).flag_2sv? %>
   <p class="form-group">
-    <%= f.check_box :requires_2sv %> <%= f.label :requires_2sv, "Requires 2SV" %>
+    <%= f.check_box :requires_2sv %> <%= f.label :requires_2sv, "Require 2-step verification" %>
   </p>
 <% end %>
 

--- a/app/views/users/_form_fields.html.erb
+++ b/app/views/users/_form_fields.html.erb
@@ -36,16 +36,18 @@
   </p>
 <% end %>
 
+<% if policy(User).flag_2sv? %>
+  <p class="checkbox">
+    <%= f.label :requires_2sv do %>
+      <%= f.check_box :requires_2sv %> Require 2-step verification
+    <% end %>
+  </p>
+<% end %>
+
 <p class="form-group">
   <%= f.label :organisation_id, "Organisation" %><br />
   <%= f.select :organisation_id, organisation_options(f), organisation_select_options, { class: "chosen-select form-control", 'data-module' => 'chosen' } %>
 </p>
-
-<% if policy(User).flag_2sv? %>
-  <p class="form-group">
-    <%= f.check_box :requires_2sv %> <%= f.label :requires_2sv, "Require 2-step verification" %>
-  </p>
-<% end %>
 
 <h2 class="add-vertical-margins">Permissions</h2>
 

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -12,6 +12,7 @@ Doorkeeper.configure do
     elsif user.need_two_step_verification? && warden.session(:user)['need_two_step_verification']
       redirect_to two_step_verification_path
     elsif user.require_2sv?
+      store_location_for(:user, request.fullpath)
       redirect_to prompt_two_step_verification_path
     else
       user

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -11,7 +11,7 @@ Doorkeeper.configure do
       redirect_to user_password_expired_path
     elsif user.need_two_step_verification? && warden.session(:user)['need_two_step_verification']
       redirect_to two_step_verification_path
-    elsif user.require_2sv?
+    elsif user.prompt_for_2sv?
       store_location_for(:user, request.fullpath)
       redirect_to prompt_two_step_verification_path
     else

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -11,6 +11,8 @@ Doorkeeper.configure do
       redirect_to user_password_expired_path
     elsif user.need_two_step_verification? && warden.session(:user)['need_two_step_verification']
       redirect_to two_step_verification_path
+    elsif user.require_2sv?
+      redirect_to prompt_two_step_verification_path
     else
       user
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Signonotron2::Application.routes.draw do
       controller: "devise/two_step_verification" do
         member do
           get :prompt
-          post :defer
+          put :defer
         end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,11 @@ Signonotron2::Application.routes.draw do
     put "/users/confirmation" => "confirmations#update"
     resource :two_step_verification, only: [:new, :create, :show, :update],
       path: "/users/two_step_verification",
-      controller: "devise/two_step_verification"
+      controller: "devise/two_step_verification" do
+        member do
+          get :prompt
+        end
+    end
   end
 
   resources :users, except: [:show] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,10 +14,10 @@ Signonotron2::Application.routes.draw do
     resource :two_step_verification, only: [:new, :create, :show, :update],
       path: "/users/two_step_verification",
       controller: "devise/two_step_verification" do
-        member do
-          get :prompt
-          put :defer
-        end
+      member do
+        get :prompt
+        put :defer
+      end
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Signonotron2::Application.routes.draw do
       controller: "devise/two_step_verification" do
         member do
           get :prompt
+          post :defer
         end
     end
   end

--- a/db/migrate/20150928115351_add_requires2sv_to_users.rb
+++ b/db/migrate/20150928115351_add_requires2sv_to_users.rb
@@ -1,0 +1,5 @@
+class AddRequires2svToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :requires_2sv, :boolean, null: false, default: false
+  end
+end

--- a/db/migrate/20150929135437_rename_users_requires2sv.rb
+++ b/db/migrate/20150929135437_rename_users_requires2sv.rb
@@ -1,0 +1,5 @@
+class RenameUsersRequires2sv < ActiveRecord::Migration
+  def change
+    rename_column :users, :requires_2sv, :require_2sv
+  end
+end

--- a/db/migrate/20151006091244_add_deferred2sv_at_to_users.rb
+++ b/db/migrate/20151006091244_add_deferred2sv_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddDeferred2svAtToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :deferred_2sv_at, :datetime, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -185,7 +185,7 @@ ActiveRecord::Schema.define(version: 20151001095709) do
     t.string   "otp_secret_key",               limit: 255
     t.integer  "second_factor_attempts_count", limit: 4,   default: 0
     t.string   "unlock_token",                 limit: 255
-    t.boolean  "requires_2sv",                             default: false,    null: false
+    t.boolean  "require_2sv",                              default: false,    null: false
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151001095709) do
+ActiveRecord::Schema.define(version: 20151006091244) do
 
   create_table "batch_invitation_application_permissions", force: :cascade do |t|
     t.integer  "batch_invitation_id",     limit: 4, null: false
@@ -186,6 +186,7 @@ ActiveRecord::Schema.define(version: 20151001095709) do
     t.integer  "second_factor_attempts_count", limit: 4,   default: 0
     t.string   "unlock_token",                 limit: 255
     t.boolean  "require_2sv",                              default: false,    null: false
+    t.datetime "deferred_2sv_at"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -185,6 +185,7 @@ ActiveRecord::Schema.define(version: 20151001095709) do
     t.string   "otp_secret_key",               limit: 255
     t.integer  "second_factor_attempts_count", limit: 4,   default: 0
     t.string   "unlock_token",                 limit: 255
+    t.boolean  "requires_2sv",                             default: false,    null: false
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/lib/roles/superadmin.rb
+++ b/lib/roles/superadmin.rb
@@ -11,7 +11,7 @@ module Roles
         :unconfirmed_email,
         :confirmation_token,
         :role,
-        :requires_2sv,
+        :require_2sv,
         { supported_permission_ids: [] },
       ]
     end

--- a/lib/roles/superadmin.rb
+++ b/lib/roles/superadmin.rb
@@ -11,6 +11,7 @@ module Roles
         :unconfirmed_email,
         :confirmation_token,
         :role,
+        :requires_2sv,
         { supported_permission_ids: [] },
       ]
     end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -101,4 +101,14 @@ describe UserPolicy do
       expect(subject).not_to permit(create(:user), User)
     end
   end
+
+  permissions :flag_2sv? do
+    it "is only allowed for superadmins" do
+      expect(subject).to permit(build(:superadmin_user), User)
+
+      expect(subject).not_to permit(create(:admin_user), User)
+      expect(subject).not_to permit(create(:organisation_admin), User)
+      expect(subject).not_to permit(create(:user), User)
+    end
+  end
 end

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -34,7 +34,7 @@ FactoryGirl.define do
     end
   end
 
-  factory :two_step_flagged_user, parent: :user do
+  factory :two_step_flagged_user, parent: :superadmin_user do
     require_2sv true
   end
 

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -34,6 +34,10 @@ FactoryGirl.define do
     end
   end
 
+  factory :two_step_flagged_user, parent: :user do
+    require_2sv true
+  end
+
   factory :user_with_pending_email_change, parent: :user do
     email "old@email.com"
     unconfirmed_email "new@email.com"

--- a/test/integration/authorise_application_test.rb
+++ b/test/integration/authorise_application_test.rb
@@ -6,6 +6,18 @@ class AuthoriseApplicationTest < ActionDispatch::IntegrationTest
     @user = create(:user)
   end
 
+  should "not confirm the authorisation if the user is flagged for 2SV" do
+    @user.update_attribute(:require_2sv, true)
+    visit "/"
+    signin(@user)
+
+    ignoring_spurious_error do
+      visit "/oauth/authorize?response_type=code&client_id=#{@app.uid}&redirect_uri=#{@app.redirect_uri}"
+    end
+
+    assert_response_contains("Setup 2-step verification")
+  end
+
   should "not confirm the authorisation until the user signs in" do
     visit "/oauth/authorize?response_type=code&client_id=#{@app.uid}&redirect_uri=#{@app.redirect_uri}"
     assert_response_contains("You need to sign in")

--- a/test/integration/authorise_application_test.rb
+++ b/test/integration/authorise_application_test.rb
@@ -15,7 +15,7 @@ class AuthoriseApplicationTest < ActionDispatch::IntegrationTest
       visit "/oauth/authorize?response_type=code&client_id=#{@app.uid}&redirect_uri=#{@app.redirect_uri}"
     end
 
-    assert_response_contains("Setup 2-step verification")
+    assert_response_contains("Make your account more secure")
   end
 
   should "not confirm the authorisation until the user signs in" do

--- a/test/integration/inviting_users_test.rb
+++ b/test/integration/inviting_users_test.rb
@@ -12,7 +12,7 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
 
       visit new_user_invitation_path
 
-      assert has_no_field?("Requires 2SV")
+      assert has_no_field?("Require 2-step verification")
     end
   end
 
@@ -69,7 +69,7 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
         fill_in "Name", with: "Fred Bloggs"
         select "Admin", from: "Role"
         fill_in "Email", with: "fred_admin@example.com"
-        check "Requires 2SV"
+        check "Require 2-step verification"
         click_button "Create user and send email"
 
         assert_not_nil User.find_by(

--- a/test/integration/inviting_users_test.rb
+++ b/test/integration/inviting_users_test.rb
@@ -75,7 +75,7 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
         assert_not_nil User.find_by(
           email: "fred_admin@example.com",
           role: "admin",
-          requires_2sv: true
+          require_2sv: true
         )
         assert_equal "fred_admin@example.com", last_email.to[0]
         assert_match 'Please confirm your account', last_email.subject

--- a/test/integration/inviting_users_test.rb
+++ b/test/integration/inviting_users_test.rb
@@ -4,6 +4,18 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
   include EmailHelpers
   include ActiveJob::TestHelper
 
+  context "for non-superadmins" do
+    should "not display the 2SV flagging checkbox" do
+      admin = create(:admin_user)
+      visit root_path
+      signin(admin)
+
+      visit new_user_invitation_path
+
+      assert has_no_field?("Requires 2SV")
+    end
+  end
+
   context "for an end-user by an admin" do
     should "create and notify the user" do
       perform_enqueued_jobs do

--- a/test/integration/inviting_users_test.rb
+++ b/test/integration/inviting_users_test.rb
@@ -57,9 +57,14 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
         fill_in "Name", with: "Fred Bloggs"
         select "Admin", from: "Role"
         fill_in "Email", with: "fred_admin@example.com"
+        check "Requires 2SV"
         click_button "Create user and send email"
 
-        assert_not_nil User.where(email: "fred_admin@example.com", role: "admin").first
+        assert_not_nil User.find_by(
+          email: "fred_admin@example.com",
+          role: "admin",
+          requires_2sv: true
+        )
         assert_equal "fred_admin@example.com", last_email.to[0]
         assert_match 'Please confirm your account', last_email.subject
       end

--- a/test/integration/two_step_verification_prompt_test.rb
+++ b/test/integration/two_step_verification_prompt_test.rb
@@ -4,7 +4,7 @@ class TwoStepVerificationPromptTest < ActionDispatch::IntegrationTest
   context 'when the user has been flagged for 2-step verification' do
     setup do
       @user = create(:two_step_flagged_user)
-      visit root_path
+      visit users_path
       signin(@user)
     end
 
@@ -13,10 +13,10 @@ class TwoStepVerificationPromptTest < ActionDispatch::IntegrationTest
     end
 
     context 'they choose to defer setup' do
-      should 'reset the 2SV flag' do
+      should 'redirect them to where they were headed originally' do
         click_button 'Not now'
 
-        assert page.has_text?('not be required to setup 2-step')
+        assert_equal users_path, page.current_path
       end
     end
 

--- a/test/integration/two_step_verification_prompt_test.rb
+++ b/test/integration/two_step_verification_prompt_test.rb
@@ -19,5 +19,13 @@ class TwoStepVerificationPromptTest < ActionDispatch::IntegrationTest
         assert page.has_text?('not be required to setup 2-step')
       end
     end
+
+    context 'they choose to setup 2-step verification' do
+      should 'direct them to setup' do
+        click_link 'Setup now'
+
+        assert page.has_text?('Set up 2-step verification')
+      end
+    end
   end
 end

--- a/test/integration/two_step_verification_prompt_test.rb
+++ b/test/integration/two_step_verification_prompt_test.rb
@@ -3,13 +3,21 @@ require 'test_helper'
 class TwoStepVerificationPromptTest < ActionDispatch::IntegrationTest
   context 'when the user has been flagged for 2-step verification' do
     setup do
-      user = create(:two_step_flagged_user)
+      @user = create(:two_step_flagged_user)
       visit root_path
-      signin(user)
+      signin(@user)
     end
 
     should 'prompt the user to complete verification' do
       assert page.has_text?('Setup 2-step verification?')
+    end
+
+    context 'they choose to defer setup' do
+      should 'reset the 2SV flag' do
+        click_button 'Continue and setup later'
+
+        assert page.has_text?('not be required to setup 2-step')
+      end
     end
   end
 end

--- a/test/integration/two_step_verification_prompt_test.rb
+++ b/test/integration/two_step_verification_prompt_test.rb
@@ -9,12 +9,12 @@ class TwoStepVerificationPromptTest < ActionDispatch::IntegrationTest
     end
 
     should 'prompt the user to complete verification' do
-      assert page.has_text?('Setup 2-step verification?')
+      assert page.has_text?('Start set up')
     end
 
     context 'they choose to defer setup' do
       should 'reset the 2SV flag' do
-        click_button 'Continue and setup later'
+        click_button 'Not now'
 
         assert page.has_text?('not be required to setup 2-step')
       end
@@ -22,7 +22,7 @@ class TwoStepVerificationPromptTest < ActionDispatch::IntegrationTest
 
     context 'they choose to setup 2-step verification' do
       should 'direct them to setup' do
-        click_link 'Setup now'
+        click_link 'Start set up'
 
         assert page.has_text?('Set up 2-step verification')
       end

--- a/test/integration/two_step_verification_prompt_test.rb
+++ b/test/integration/two_step_verification_prompt_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class TwoStepVerificationPromptTest < ActionDispatch::IntegrationTest
+  context 'when the user has been flagged for 2-step verification' do
+    setup do
+      user = create(:two_step_flagged_user)
+      visit root_path
+      signin(user)
+    end
+
+    should 'prompt the user to complete verification' do
+      assert page.has_text?('Setup 2-step verification?')
+    end
+  end
+end

--- a/test/integration/two_step_verification_test.rb
+++ b/test/integration/two_step_verification_test.rb
@@ -20,8 +20,8 @@ class TwoStepVerificationTest < ActionDispatch::IntegrationTest
 
     context "without an existing 2SV setup" do
       setup do
-        @user = create(:user, email: "jane.user@example.com", require_2sv: true)
-        visit new_user_session_path
+        @user = create(:admin_user, email: "jane.user@example.com", require_2sv: true)
+        visit users_path
         signin(@user)
         @secret = ROTP::Base32.random_base32
         ROTP::Base32.stubs(random_base32: @secret)
@@ -73,6 +73,10 @@ class TwoStepVerificationTest < ActionDispatch::IntegrationTest
 
         should "reset the `require_2sv` flag" do
           refute @user.reload.require_2sv?
+        end
+
+        should "direct them back to where they were originally headed" do
+          assert_equal users_path, current_path
         end
       end
     end

--- a/test/integration/two_step_verification_test.rb
+++ b/test/integration/two_step_verification_test.rb
@@ -71,10 +71,6 @@ class TwoStepVerificationTest < ActionDispatch::IntegrationTest
           assert_equal 1, EventLog.where(event: EventLog::TWO_STEP_ENABLED, uid: @user.uid).count
         end
 
-        should "reset the `require_2sv` flag" do
-          refute @user.reload.require_2sv?
-        end
-
         should "direct them back to where they were originally headed" do
           assert_equal users_path, current_path
         end

--- a/test/integration/two_step_verification_test.rb
+++ b/test/integration/two_step_verification_test.rb
@@ -20,7 +20,7 @@ class TwoStepVerificationTest < ActionDispatch::IntegrationTest
 
     context "without an existing 2SV setup" do
       setup do
-        @user = create(:user, email: "jane.user@example.com")
+        @user = create(:user, email: "jane.user@example.com", require_2sv: true)
         visit new_user_session_path
         signin(@user)
         @secret = ROTP::Base32.random_base32
@@ -69,6 +69,10 @@ class TwoStepVerificationTest < ActionDispatch::IntegrationTest
 
         should "log the set up in the event log" do
           assert_equal 1, EventLog.where(event: EventLog::TWO_STEP_ENABLED, uid: @user.uid).count
+        end
+
+        should "reset the `require_2sv` flag" do
+          refute @user.reload.require_2sv?
         end
       end
     end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -9,25 +9,25 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "`require_2sv` defaults to false" do
-    refute build(:user).require_2sv?
+    refute build(:user).require_2sv
   end
 
-  context '#require_2sv?' do
+  context '#prompt_for_2sv?' do
     context 'when the user has already enrolled' do
       should 'always be false' do
-        refute build(:two_step_flagged_user, otp_secret_key: 'welp').require_2sv?
+        refute build(:two_step_flagged_user, otp_secret_key: 'welp').prompt_for_2sv?
       end
     end
 
     context 'when the user deferred within the last 24hrs' do
       should 'be false' do
-        refute build(:two_step_flagged_user, deferred_2sv_at: 3.hours.ago).require_2sv?
+        refute build(:two_step_flagged_user, deferred_2sv_at: 3.hours.ago).prompt_for_2sv?
       end
     end
 
     context 'when the user deferred more than 24hrs ago' do
       should 'be true' do
-        assert build(:two_step_flagged_user, deferred_2sv_at: 25.hours.ago).require_2sv?
+        assert build(:two_step_flagged_user, deferred_2sv_at: 25.hours.ago).prompt_for_2sv?
       end
     end
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -12,6 +12,21 @@ class UserTest < ActiveSupport::TestCase
     refute build(:user).require_2sv?
   end
 
+  context '#defer_two_step_verification' do
+    setup do
+      @user = create(:two_step_flagged_user)
+      @user.defer_two_step_verification
+    end
+
+    should 'reset the `require_2sv` flag' do
+      refute @user.require_2sv?
+    end
+
+    should 'record an event' do
+      EventLog.find_by!(event: EventLog::TWO_STEP_PROMPT_DEFERRED, uid: @user.uid)
+    end
+  end
+
   test "email change tokens should expire" do
     @user = create(:user_with_pending_email_change, confirmation_sent_at: 15.days.ago)
     @user.confirm

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -39,6 +39,10 @@ class UserTest < ActiveSupport::TestCase
       refute @user.require_2sv?
     end
 
+    should 'touch the `deferred_2sv_at` timestamp' do
+      assert @user.deferred_2sv_at?
+    end
+
     should 'record an event' do
       EventLog.find_by!(event: EventLog::TWO_STEP_PROMPT_DEFERRED, uid: @user.uid)
     end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -38,10 +38,6 @@ class UserTest < ActiveSupport::TestCase
       @user.defer_two_step_verification
     end
 
-    should 'reset the `require_2sv` flag' do
-      refute @user.require_2sv
-    end
-
     should 'touch the `deferred_2sv_at` timestamp' do
       assert @user.deferred_2sv_at?
     end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -8,6 +8,10 @@ class UserTest < ActiveSupport::TestCase
     @user = create(:user)
   end
 
+  test "`requires_2sv` defaults to false" do
+    refute build(:user).requires_2sv?
+  end
+
   test "email change tokens should expire" do
     @user = create(:user_with_pending_email_change, confirmation_sent_at: 15.days.ago)
     @user.confirm

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -21,6 +21,14 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
+  context '#require_2sv?' do
+    context 'when the user has already enrolled' do
+      should 'always be false' do
+        refute build(:two_step_flagged_user, otp_secret_key: 'welp').require_2sv?
+      end
+    end
+  end
+
   context '#defer_two_step_verification' do
     setup do
       @user = create(:two_step_flagged_user)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -12,15 +12,6 @@ class UserTest < ActiveSupport::TestCase
     refute build(:user).require_2sv?
   end
 
-  context '#require_2sv validation' do
-    should 'not be permitted when the user has already setup 2SV' do
-      user = build(:user, otp_secret_key: 'something')
-      user.require_2sv = true
-
-      assert user.invalid?
-    end
-  end
-
   context '#require_2sv?' do
     context 'when the user has already enrolled' do
       should 'always be false' do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -43,7 +43,7 @@ class UserTest < ActiveSupport::TestCase
     end
 
     should 'record an event' do
-      EventLog.find_by!(event: EventLog::TWO_STEP_PROMPT_DEFERRED, uid: @user.uid)
+      assert_equal 1, EventLog.where(event: EventLog::TWO_STEP_PROMPT_DEFERRED, uid: @user.uid).count
     end
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -27,6 +27,18 @@ class UserTest < ActiveSupport::TestCase
         refute build(:two_step_flagged_user, otp_secret_key: 'welp').require_2sv?
       end
     end
+
+    context 'when the user deferred within the last 24hrs' do
+      should 'be false' do
+        refute build(:two_step_flagged_user, deferred_2sv_at: 3.hours.ago).require_2sv?
+      end
+    end
+
+    context 'when the user deferred more than 24hrs ago' do
+      should 'be true' do
+        assert build(:two_step_flagged_user, deferred_2sv_at: 25.hours.ago).require_2sv?
+      end
+    end
   end
 
   context '#defer_two_step_verification' do
@@ -36,7 +48,7 @@ class UserTest < ActiveSupport::TestCase
     end
 
     should 'reset the `require_2sv` flag' do
-      refute @user.require_2sv?
+      refute @user.require_2sv
     end
 
     should 'touch the `deferred_2sv_at` timestamp' do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -12,6 +12,15 @@ class UserTest < ActiveSupport::TestCase
     refute build(:user).require_2sv?
   end
 
+  context '#require_2sv validation' do
+    should 'not be permitted when the user has already setup 2SV' do
+      user = build(:user, otp_secret_key: 'something')
+      user.require_2sv = true
+
+      assert user.invalid?
+    end
+  end
+
   context '#defer_two_step_verification' do
     setup do
       @user = create(:two_step_flagged_user)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -8,8 +8,8 @@ class UserTest < ActiveSupport::TestCase
     @user = create(:user)
   end
 
-  test "`requires_2sv` defaults to false" do
-    refute build(:user).requires_2sv?
+  test "`require_2sv` defaults to false" do
+    refute build(:user).require_2sv?
   end
 
   test "email change tokens should expire" do


### PR DESCRIPTION

Provides the ability for super admins to flag users as requiring 2SV. Once they've been flagged they will be prompted to complete 2SV enrolment and cannot do much until they enrol or defer.