### PR TITLE
Consolidate the Sidekiq config with production

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,11 +1,15 @@
-# This file is overwritten on deploy
+require "sidekiq"
+
+redis_config = { namespace: "signon_sidekiq" }
+redis_config[:url] = ENV['REDIS_URL'] if ENV['REDIS_URL']
+
+Sidekiq.configure_server do |config|
+  config.redis = redis_config
+  config.server_middleware do |chain|
+    chain.add Sidekiq::Statsd::ServerMiddleware, env: 'govuk.app.signon', prefix: 'workers'
+  end
+end
 
 Sidekiq.configure_client do |config|
-  config.redis = { namespace: 'signon' }
-end
-Sidekiq.configure_server do |config|
-  config.redis = { namespace: 'signon' }
-  config.server_middleware do |chain|
-    chain.add Sidekiq::Middleware::Server::RetryJobs, max_retries: 5
-  end
+  config.redis = redis_config
 end


### PR DESCRIPTION
This change replaces the development sidekiq initialiser with the production one.

Taking the redis URL from the environment will allow to have one common
config and not replace the initializer in 'alphagov-deployment'.

This can be safely merged now because for the time being, `config/initializers/sidekiq.rb` is still being replaced during deployment.