### PR TITLE
Unlocking after too many 2SV attempts

### DIFF
--- a/app/controllers/devise/two_step_verification_controller.rb
+++ b/app/controllers/devise/two_step_verification_controller.rb
@@ -23,10 +23,7 @@ class Devise::TwoStepVerificationController < DeviseController
       sign_in :user, current_user, bypass: true
       set_flash_message :notice, :success
       redirect_to stored_location_for(:user) || :root
-      current_user.update_attribute(:second_factor_attempts_count, 0)
     else
-      current_user.second_factor_attempts_count += 1
-      current_user.save
       flash.now[:error] = find_message(:attempt_failed)
       if current_user.max_2sv_login_attempts?
         sign_out(current_user)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,6 @@
 class SessionsController < Devise::SessionsController
+  skip_before_action :handle_two_step_verification
+
   def destroy
     ReauthEnforcer.perform_on(current_user) if current_user
     super

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,5 +1,6 @@
-class UserMailer < ActionMailer::Base
+class UserMailer < Devise::Mailer
   include MailerHelper
+  append_view_path Rails.root.join("app/views/devise/mailer")
 
   default from: Proc.new { email_from }
 
@@ -14,11 +15,6 @@ class UserMailer < ActionMailer::Base
   def suspension_notification(user)
     @user = user
     mail(to: @user.email, subject: suspension_notification_subject)
-  end
-
-  def locked_account_explanation(user)
-    @user = user
-    mail(to: @user.email, subject: locked_account_explanation_subject)
   end
 
   def notify_reset_password_disallowed_due_to_suspension(user)
@@ -54,10 +50,6 @@ private
     "Your #{app_name} account has been suspended"
   end
 
-  def locked_account_explanation_subject
-    "Your #{app_name} account has been locked"
-  end
-
   def locked_time
     @user.locked_at.to_s(:govuk_date)
   end
@@ -72,5 +64,10 @@ private
     else
       "account"
     end
+  end
+
+  def subject_for(key)
+    I18n.t(:"#{devise_mapping.name}_subject", scope: [:devise, :mailer, key],
+      default: [:subject, key.to_s.humanize], app_name: app_name)
   end
 end

--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -1,7 +1,9 @@
 class EventLog < ActiveRecord::Base
   include ActiveModel::ForbiddenAttributesProtection
 
-  ACCOUNT_LOCKED = "Account locked"
+  LOCKED_DURATION = "#{Devise.unlock_in / 1.hour} #{'hour'.pluralize(Devise.unlock_in / 1.hour)}"
+
+  ACCOUNT_LOCKED = "Passphrase verification failed too many times, account locked for #{LOCKED_DURATION}"
   ACCOUNT_SUSPENDED = "Account suspended"
   ACCOUNT_UNSUSPENDED = "Account unsuspended"
   ACCOUNT_AUTOSUSPENDED = "Account auto-suspended"
@@ -22,7 +24,7 @@ class EventLog < ActiveRecord::Base
   TWO_STEP_ENABLE_FAILED = "2-step verification setup failed"
   TWO_STEP_VERIFIED = "2-step verification successful"
   TWO_STEP_VERIFICATION_FAILED = "2-step verification failed"
-  TWO_STEP_LOCKED = "2-step verification failed too many times"
+  TWO_STEP_LOCKED = "2-step verification failed too many times, account locked for #{LOCKED_DURATION}"
 
   # API users
   API_USER_CREATED = "Account created"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -179,8 +179,6 @@ class User < ActiveRecord::Base
   def lock_access!
     EventLog.record_event(User.find_by_email(self.email), EventLog::ACCOUNT_LOCKED)
     super
-
-    UserMailer.locked_account_explanation(self).deliver_later
   end
 
   def status

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -234,6 +234,11 @@ class User < ActiveRecord::Base
     second_factor_attempts_count.to_i >= MAX_2SV_LOGIN_ATTEMPTS.to_i
   end
 
+  def unlock_access! *args
+    super
+    update_attribute(:second_factor_attempts_count, 0)
+  end
+
 private
 
   # Override devise_security_extension for updating expired passwords

--- a/app/views/devise/_links.erb
+++ b/app/views/devise/_links.erb
@@ -10,10 +10,6 @@
   <%= link_to t('.forgot_passphrase'), new_password_path(resource_name) %><br />
 <% end -%>
 
-<%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to t('.no_unlock_instructions'), new_unlock_path(resource_name) %><br />
-<% end -%>
-
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
     <%= link_to t('.signin_with_omniauth', :provider =>  provider.to_s.titleize), omniauth_authorize_path(resource_name, provider) %><br />

--- a/app/views/devise/two_step_verification/max_2sv_login_attempts_reached.html.erb
+++ b/app/views/devise/two_step_verification/max_2sv_login_attempts_reached.html.erb
@@ -6,7 +6,13 @@
 </div>
 
 <div class="callout callout-danger">
-  <p class="lead remove-bottom-margin">
+  <p class="lead">
     Your account has been locked because an incorrect 2-step verification code was entered too many times.
+  </p>
+  <p>Your account will be unlocked at <%= Devise.unlock_in.from_now.to_s(:govuk_time)%></p>
+  <p>
+    If you need your account unlocked sooner, please contact a managing GOV.UK editor in your organisation
+    (or your parent organisation). They can either unlock your account themselves or use the support form
+    to get help from the GOV.UK team.
   </p>
 </div>

--- a/app/views/user_mailer/unlock_instructions.html.erb
+++ b/app/views/user_mailer/unlock_instructions.html.erb
@@ -1,6 +1,6 @@
-<p>Hello <%= @user.name %>,</p>
+<p>Hello <%= @resource.name %>,</p>
 
-<p>Your <%= link_to 'GOV.UK', "https://www.gov.uk" %> Signon <%= account_name %>, for <%= @user.email %>, was locked at <%= locked_time %> because the wrong sign on details were entered too many times.</p>
+<p>Your <%= link_to 'GOV.UK', "https://www.gov.uk" %> Signon <%= account_name %>, for <%= @resource.email %>, was locked at <%= locked_time %> because the wrong sign on details were entered too many times.</p>
 
 <% if instance_name.present? %>
 <p><%= account_name.humanize %> locks do not lock production accounts.</p>

--- a/app/views/user_mailer/unlock_instructions.text.erb
+++ b/app/views/user_mailer/unlock_instructions.text.erb
@@ -1,6 +1,6 @@
-Hello <%= @user.name %>,
+Hello <%= @resource.name %>,
 
-Your GOV.UK Signon <%= account_name %>, for <%= @user.email %>, was locked at <%= locked_time %> because the wrong sign on details were entered too many times.
+Your GOV.UK Signon <%= account_name %>, for <%= @resource.email %>, was locked at <%= locked_time %> because the wrong sign on details were entered too many times.
 
 <% if instance_name.present? %>
   <%= account_name.humanize %> locks do not lock production accounts.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -10,7 +10,7 @@ Devise.setup do |config|
   config.mailer_sender = Class.new.extend(MailerHelper).email_from
 
   # Configure the class responsible to send e-mails.
-  # config.mailer = "Devise::Mailer"
+  config.mailer = "UserMailer"
 
   # ==> ORM configuration
   # Load and configure the ORM. Supports :active_record (default) and
@@ -174,7 +174,7 @@ Devise.setup do |config|
   # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
   # :both  = Enables both strategies
   # :none  = No unlock strategy. You should handle unlocking by yourself.
-  config.unlock_strategy = :time
+  config.unlock_strategy = :both
 
   # Number of authentication tries before locking an account if lock_strategy
   # is failed attempts.

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -59,7 +59,7 @@ en:
       reset_password_instructions:
         subject: 'Reset passphrase instructions'
       unlock_instructions:
-        subject: 'Unlock Instructions'
+        subject: 'Your %{app_name} account has been locked'
     links:
       signup: "Sign up"
       signin: "Sign in"

--- a/db/migrate/20151001095709_add_unlock_token_to_users.rb
+++ b/db/migrate/20151001095709_add_unlock_token_to_users.rb
@@ -1,0 +1,6 @@
+class AddUnlockTokenToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :unlock_token, :string, length: 64
+    add_index :users, :unlock_token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150811150231) do
+ActiveRecord::Schema.define(version: 20151001095709) do
 
   create_table "batch_invitation_application_permissions", force: :cascade do |t|
     t.integer  "batch_invitation_id",     limit: 4, null: false
@@ -184,6 +184,7 @@ ActiveRecord::Schema.define(version: 20150811150231) do
     t.datetime "invitation_created_at"
     t.string   "otp_secret_key",               limit: 255
     t.integer  "second_factor_attempts_count", limit: 4,   default: 0
+    t.string   "unlock_token",                 limit: 255
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
@@ -192,5 +193,6 @@ ActiveRecord::Schema.define(version: 20150811150231) do
   add_index "users", ["organisation_id"], name: "index_users_on_organisation_id", using: :btree
   add_index "users", ["otp_secret_key"], name: "index_users_on_otp_secret_key", unique: true, using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
+  add_index "users", ["unlock_token"], name: "index_users_on_unlock_token", using: :btree
 
 end

--- a/test/integration/event_log_test.rb
+++ b/test/integration/event_log_test.rb
@@ -216,7 +216,7 @@ class EventLogIntegrationTest < ActionDispatch::IntegrationTest
   def assert_account_access_log_page_content(user)
     assert_text 'Time'
     assert_text 'Event'
-    assert_text 'Account locked'
+    assert_text 'account locked'
     assert_selector "a", text: user.name
   end
 end

--- a/test/integration/event_log_test.rb
+++ b/test/integration/event_log_test.rb
@@ -214,9 +214,9 @@ class EventLogIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   def assert_account_access_log_page_content(user)
-    assert page.has_content?('Time')
-    assert page.has_content?('Event')
-    assert page.has_content?('Account locked')
-    assert page.has_link?("#{user.name}")
+    assert_text 'Time'
+    assert_text 'Event'
+    assert_text 'Account locked'
+    assert_selector "a", text: user.name
   end
 end

--- a/test/integration/sign_in_test.rb
+++ b/test/integration/sign_in_test.rb
@@ -193,6 +193,14 @@ class SignInTest < ActionDispatch::IntegrationTest
       assert_response_contains "get your code"
       assert_selector "input[name=code]"
     end
+
+    should "allow the user to cancel 2SV by signing out" do
+      visit root_path
+      signin(email: "email@example.com", password: "some passphrase with various $ymb0l$")
+      click_link "Sign out"
+
+      assert_text "Signed out successfully."
+    end
   end
 
   should "not display a link to resend unlock instructions" do

--- a/test/integration/sign_in_test.rb
+++ b/test/integration/sign_in_test.rb
@@ -150,11 +150,14 @@ class SignInTest < ActionDispatch::IntegrationTest
       visit root_path
       signin(email: "email@example.com", password: "some passphrase with various $ymb0l$")
 
-      User::MAX_2SV_LOGIN_ATTEMPTS.times do
-        fill_in :code, with: "abcdef"
-        click_button "Sign in"
-      end
+      Timecop.freeze do
+        User::MAX_2SV_LOGIN_ATTEMPTS.times do
+          fill_in :code, with: "abcdef"
+          click_button "Sign in"
+        end
 
+        assert_response_contains 1.hour.from_now.to_s(:govuk_time)
+      end
       assert_response_contains "entered too many times"
       assert_equal 1, EventLog.where(event: EventLog::TWO_STEP_LOCKED, uid: @user.uid).count
     end

--- a/test/integration/sign_in_test.rb
+++ b/test/integration/sign_in_test.rb
@@ -194,4 +194,9 @@ class SignInTest < ActionDispatch::IntegrationTest
       assert_selector "input[name=code]"
     end
   end
+
+  should "not display a link to resend unlock instructions" do
+    visit root_path
+    refute_selector "a", text: "Didn't receive unlock instructions?"
+  end
 end

--- a/test/integration/sign_in_test.rb
+++ b/test/integration/sign_in_test.rb
@@ -147,9 +147,13 @@ class SignInTest < ActionDispatch::IntegrationTest
     end
 
     should "prevent access if max attempts reached" do
-      @user.update_attribute(:second_factor_attempts_count, User::MAX_2SV_LOGIN_ATTEMPTS)
       visit root_path
       signin(email: "email@example.com", password: "some passphrase with various $ymb0l$")
+
+      User::MAX_2SV_LOGIN_ATTEMPTS.times do
+        fill_in :code, with: "abcdef"
+        click_button "Sign in"
+      end
 
       assert_response_contains "entered too many times"
       assert_equal 1, EventLog.where(event: EventLog::TWO_STEP_LOCKED, uid: @user.uid).count

--- a/test/models/user_mailer_test.rb
+++ b/test/models/user_mailer_test.rb
@@ -65,8 +65,8 @@ class UserMailerTest < ActionMailer::TestCase
     setup do
       Rails.application.config.stubs(:instance_name).returns("test")
       @the_time = Time.zone.now
-      stub_user = stub(name: "User", email: "user@example.com", locked_at: @the_time)
-      @email = UserMailer.locked_account_explanation(stub_user)
+      user = User.new(name: "User", email: "user@example.com", locked_at: @the_time)
+      @email = UserMailer.unlock_instructions(user, "afaketoken")
     end
 
     should "state when the account was locked" do


### PR DESCRIPTION
https://trello.com/c/LYxVsMEb/114-unlocking-after-too-many-2sv-attempts-medium-ish

This is an implementation of the locking/unlocking requirement which piggy-backs on the devise locakble module. Instead of maintaining a separate locking behaviour for 2SV, we re-use the `User#lock_access!` and `User#unlock_access!` methods. 

This also refactors the locked account email to use the Devise unlock instructions built in email, reducing app-specific complexity. This requires setting up an unlock token for a user, but this isn't currently exposed in the email, so isn't usable by the user.

The potential downside to this method is that the user is locked out completely from logging in, if they enter 2SV incorrectly too many times, they are sent back to the email / passphrase screen. When they enter their credentials correctly, they are given an error message saying "Invalid email/passphrase". This is valid behaviour for an attacker attempting to guess a user's passphrase, but could be misleading for a user who has entered 2SV incorrectly.

This copy could be changed to something like:

"You have entered your credentials incorrectly, or your account may be locked for too many incorrect attempts"