### PR TITLE
Redact email addresses from analytics

### DIFF
--- a/app/controllers/suspensions_controller.rb
+++ b/app/controllers/suspensions_controller.rb
@@ -16,7 +16,7 @@ class SuspensionsController < ApplicationController
       PermissionUpdater.perform_on(@user)
       ReauthEnforcer.perform_on(@user)
 
-      flash[:notice] = "#{@user.name} is now #{@user.suspended? ? 'suspended' : 'active'}."
+      flash[:notice] = "#{@user.email} is now #{@user.suspended? ? 'suspended' : 'active'}."
 
       redirect_to @user.api_user? ? edit_api_user_path(@user) : edit_user_path(@user)
     else

--- a/app/helpers/bootstrap_flash_helper.rb
+++ b/app/helpers/bootstrap_flash_helper.rb
@@ -13,4 +13,11 @@ module BootstrapFlashHelper
       flash_key
     end
   end
+
+  def flash_text_without_email_addresses(message)
+    text_message = strip_tags(message)
+
+    # redact email addresses so they aren't passed to GA
+    text_message.gsub(/[\S]+@[\S]+/, '[email]')
+  end
 end

--- a/app/views/shared/_bootstrap_flash_messages.html.erb
+++ b/app/views/shared/_bootstrap_flash_messages.html.erb
@@ -2,7 +2,7 @@
   <div class="alert alert-<%= bootstrap_flash_class(k) %>"
     data-module="auto-track-event"
     data-track-action="alert-<%= bootstrap_flash_class(k) %>"
-    data-track-label="<%= strip_tags(flash[k]) %>">
+    data-track-label="<%= flash_text_without_email_addresses(flash[k]) %>">
       <%= flash[k] %>
   </div>
 <% end %>

--- a/test/integration/manage_api_users_test.rb
+++ b/test/integration/manage_api_users_test.rb
@@ -111,7 +111,7 @@ class ManageApiUsersTest < ActionDispatch::IntegrationTest
       uncheck "Suspended?"
       click_button "Save"
 
-      assert page.has_selector?(".alert-success", text: "#{@api_user.name} is now active.")
+      assert page.has_selector?(".alert-success", text: "#{@api_user.email} is now active.")
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/kEt8UXfz/129-personally-identifiable-information-in-google-analytics-medium

Don’t pass user email address to Google Analytics. Replace with “[email]”. This is the same pattern as used by the Support app.

Update a single flash message to use emails rather than names to
* be consistent with other flash messages
* allow personal information to be redaction
* make it easier for a user to follow up with a message to the suspended/unsuspended user