### PR TITLE
[Do not merge] Preserve the referring host for successful sign in redirect

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -42,4 +42,14 @@ class ApplicationController < ActionController::Base
   def redirect_to_prior_flow(args = {})
     redirect_to stored_location_for(:user) || :root, args
   end
+
+  def store_full_location_for(resource_or_scope, location)
+    session_key = stored_location_key_for(resource_or_scope)
+    uri = parse_uri(location)
+    if uri && uri.host =~ %r{\.#{Plek.new.parent_domain}$}
+      session[session_key] = uri.to_s
+    else
+      session[session_key] = root_path
+    end
+  end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,7 +7,7 @@ class SessionsController < Devise::SessionsController
   end
 
   def new
-    store_location_for(:user, request.referer) if request.get?
+    store_full_location_for(:user, request.referer) if request.get?
     super
   end
 

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+class SessionsControllerTest < ActionController::TestCase
+  setup do
+    @request.env["devise.mapping"] = Devise.mappings[:user]
+  end
+
+  context "GET new" do
+    context "when referred by a GOV.UK app" do
+      should "store the full referrer to be redirected to later" do
+        @request.env["HTTP_REFERER"] = "http://service.dev.gov.uk/bar"
+        get :new
+        assert_equal "http://service.dev.gov.uk/bar", session["user_return_to"]
+      end
+    end
+
+    context "when referred by a non GOV.UK url" do
+      should "store the root path to be redirected to later" do
+        @request.env["HTTP_REFERER"] = "http://attacker.com/bar"
+        get :new
+        assert_equal "/", session["user_return_to"]
+      end
+    end
+  end
+end


### PR DESCRIPTION
Using `store_location_for` strips the hostname from the provided
location before storing it in the session, meaning the app will
eventually redirect to a relative URL after a successful sign in. This
meant that users weren’t redirected to their desired application if
they had been redirect to signon from the app.

The new `store_full_location_for` method is based on the original
`store_location_for` implementation: http://bit.ly/1Nps7U6, and
additionally ensures the host is part of the GOV.UK parent domain as
provided by Plek

Added tests to verify this behaviour.

/cc @benilovj @jamiecobbett 