### PR TITLE
Add ability for users to change the device used for 2SV

### DIFF
--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -25,6 +25,8 @@ class EventLog < ActiveRecord::Base
   TWO_STEP_VERIFIED = "2-step verification successful"
   TWO_STEP_VERIFICATION_FAILED = "2-step verification failed"
   TWO_STEP_LOCKED = "2-step verification failed too many times, account locked for #{LOCKED_DURATION}"
+  TWO_STEP_CHANGED = "2-step verification phone changed"
+  TWO_STEP_CHANGE_FAILED = "2-step verification phone change failed"
 
   # API users
   API_USER_CREATED = "Account created"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -203,7 +203,7 @@ class User < ActiveRecord::Base
   end
 
   def need_two_step_verification?
-    otp_secret_key.present?
+    has_2sv?
   end
 
   def authenticate_otp(code)
@@ -237,6 +237,10 @@ class User < ActiveRecord::Base
   def unlock_access! *args
     super
     update_attribute(:second_factor_attempts_count, 0)
+  end
+
+  def has_2sv?
+    otp_secret_key.present?
   end
 
 private

--- a/app/views/devise/two_step_verification/show.html.erb
+++ b/app/views/devise/two_step_verification/show.html.erb
@@ -1,9 +1,15 @@
-<% content_for :title, "Set up 2-step verification" %>
+<% title = current_user.has_2sv? ? "Use a new phone" : "Set up 2-step verification" %>
+<% content_for :title, title %>
 <% invalid_code_entered = flash[:invalid_code] %>
 
-<h1>Set up 2-step verification</h1>
+<h1><%= title %></h1>
 <div class="row">
   <div class="col-md-8">
+    <% if current_user.has_2sv? %>
+      <div class="alert alert-warning">
+        <p>Setting up a new phone will replace your existing one. You will only be able to sign in with your new phone.</p>
+      </div>
+    <% end %>
     <p class="lead">Make your signon account more secure by setting up 2-step verification. You’ll need to install an app on your phone which will generate a security code to enter when you sign in.</p>
 
     <div class="panel-group" id="setup-steps" role="tablist" aria-multiselectable="true">
@@ -85,7 +91,13 @@
                     placeholder: 'Enter 6-digit code',
                     autocomplete: 'off' %>
                 </div>
-                <button name="submit" id="submit_code" class="btn btn-lg btn-success">Finish set up</button>
+                <button name="submit" id="submit_code" class="btn btn-lg btn-success">
+                  <% if current_user.has_2sv? %>
+                    Finish replacing your phone
+                  <% else %>
+                    Finish set up
+                  <% end %>
+                </button>
                 <a href="/" class="btn btn-lg btn-default add-left-margin">Cancel</a>
               <% end %>
           </div>

--- a/app/views/devise/two_step_verification/show.html.erb
+++ b/app/views/devise/two_step_verification/show.html.erb
@@ -76,7 +76,7 @@
                   <%= invalid_code_entered %>
                 </div>
               <% end %>
-              <%= form_tag two_step_verification_path do %>
+              <%= form_tag two_step_verification_path, method: :put do %>
                 <%= hidden_field_tag :otp_secret_key, @otp_secret_key%>
                 <div class="form-group <% if invalid_code_entered %>has-error text-danger<% end %>">
                   <%= label_tag :code, 'Code from your phone' %>

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -5,9 +5,12 @@
 <div class="well">
 <div class="row">
   <div class="col-md-4">
-  <h2 class="remove-top-margin">Your account</h2>
+  <h2 class="remove-top-margin add-bottom-margin">Your account</h2>
   <ul>
     <li><%= link_to "Change your email or passphrase", edit_email_or_passphrase_user_path(current_user) %></li>
+    <% if current_user.has_2sv? %>
+      <li><%= link_to "Change your 2-step verification phone", two_step_verification_path %></li>
+    <% end %>
     <li><%= link_to "Sign out", destroy_user_session_path %></li>
   </ul>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,11 @@ en:
       password_format: "must contain big, small letters and digits"
 
   devise:
+    two_step_verification:
+      messages:
+        success:
+          change: "2-step verification phone changed successfully"
+          setup: "2-step verification set up"
     two_step_verification_session:
       success: "Signed in successfully."
       attempt_failed: "Sorry, that code didn’t work."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Signonotron2::Application.routes.draw do
   devise_scope :user do
     post "/users/invitation/resend/:id" => "invitations#resend", :as => "resend_user_invitation"
     put "/users/confirmation" => "confirmations#update"
-    resource :two_step_verification, only: [:new, :create],
+    resource :two_step_verification, only: [:show, :update],
       path: "/users/two_step_verification",
       controller: "devise/two_step_verification" do
       resource :session, only: [:new, :create], controller: "devise/two_step_verification_session"

--- a/test/controllers/two_step_verification_controller_test.rb
+++ b/test/controllers/two_step_verification_controller_test.rb
@@ -14,7 +14,7 @@ class TwoStepVerificationControllerTest < ActionController::TestCase
       @secret = ROTP::Base32.random_base32
       ROTP::Base32.stubs(random_base32: @secret)
 
-      get :new
+      get :show
     end
 
     should "include the secret key uppercased" do

--- a/test/integration/two_step_verification_test.rb
+++ b/test/integration/two_step_verification_test.rb
@@ -17,8 +17,9 @@ class TwoStepVerificationTest < ActionDispatch::IntegrationTest
         visit two_step_verification_path
       end
 
-      should "show the TOTP secret" do
+      should "show the TOTP secret and a warning" do
         assert_response_contains "Enter the code manually: #{@secret}"
+        assert_response_contains "Setting up a new phone will replace your existing one. You will only be able to sign in with your new phone."
       end
 
       should "reject an invalid code, reuse the secret and log the rejection" do

--- a/test/integration/two_step_verification_test.rb
+++ b/test/integration/two_step_verification_test.rb
@@ -3,74 +3,77 @@ require 'test_helper'
 require 'helpers/passphrase_support'
 
 class TwoStepVerificationTest < ActionDispatch::IntegrationTest
-  context "setting up" do
+  context "setting a 2SV code" do
+    setup do
+      @secret = ROTP::Base32.random_base32
+      ROTP::Base32.stubs(random_base32: @secret)
+    end
+
     context "with an existing 2SV setup" do
       setup do
         @user = create(:user, email: "jane.user@example.com", otp_secret_key: ROTP::Base32.random_base32)
         visit new_user_session_path
         signin_with_2sv(@user)
-        visit new_two_step_verification_path
-      end
-
-      should "redirect to homepage" do
-        assert_response_contains "2-step verification is already set up"
-        assert_response_contains "Welcome to GOV.UK"
-      end
-    end
-
-    context "without an existing 2SV setup" do
-      setup do
-        @user = create(:user, email: "jane.user@example.com")
-        visit new_user_session_path
-        signin(@user)
-        @secret = ROTP::Base32.random_base32
-        ROTP::Base32.stubs(random_base32: @secret)
-        visit new_two_step_verification_path
+        visit two_step_verification_path
       end
 
       should "show the TOTP secret" do
         assert_response_contains "Enter the code manually: #{@secret}"
       end
 
-      context "with an incorrect code entered" do
-        setup do
-          fill_in "code", with: "abcdef"
-          click_button "submit_code"
-        end
+      should "reject an invalid code, reuse the secret and log the rejection" do
+        fill_in "code", with: "abcdef"
+        click_button "submit_code"
 
-        should "reject the code" do
-          assert_response_contains "Sorry that code didn’t work. Please try again."
-        end
-
-        should "show the same secret" do
-          assert_response_contains "Enter the code manually: #{@secret}"
-        end
-
-        should "log the failure in the event log" do
-          assert_equal 1, EventLog.where(event: EventLog::TWO_STEP_ENABLE_FAILED, uid: @user.uid).count
-        end
+        assert_response_contains "Sorry that code didn’t work. Please try again."
+        assert_response_contains "Enter the code manually: #{@secret}"
+        assert_equal 1, EventLog.where(event: EventLog::TWO_STEP_CHANGE_FAILED, uid: @user.uid).count
       end
 
-      context "with the correct code entered" do
-        setup do
-          Timecop.freeze do
-            fill_in "code", with: ROTP::TOTP.new(@secret).now
-            click_button "submit_code"
-          end
-        end
+      should "accept a valid code, persist the secret and log the event" do
+        enter_code
 
-        should "accept the code" do
-          assert_response_contains "2-step verification set up"
-        end
-
-        should "persist the confirmed secret" do
-          assert_equal @secret, @user.reload.otp_secret_key
-        end
-
-        should "log the set up in the event log" do
-          assert_equal 1, EventLog.where(event: EventLog::TWO_STEP_ENABLED, uid: @user.uid).count
-        end
+        assert_response_contains "2-step verification phone changed successfully"
+        assert_equal @secret, @user.reload.otp_secret_key
+        assert_equal 1, EventLog.where(event: EventLog::TWO_STEP_CHANGED, uid: @user.uid).count
       end
+    end
+
+    context "for a user without an existing 2SV setup" do
+      setup do
+        @user = create(:user, email: "jane.user@example.com")
+        visit users_path
+        signin(@user)
+        visit two_step_verification_path
+      end
+
+      should "show the TOTP secret" do
+        assert_response_contains "Enter the code manually: #{@secret}"
+      end
+
+      should "reject an invalid code, reuse the secret and log the rejection" do
+        fill_in "code", with: "abcdef"
+        click_button "submit_code"
+
+        assert_response_contains "Sorry that code didn’t work. Please try again."
+        assert_response_contains "Enter the code manually: #{@secret}"
+        assert_equal 1, EventLog.where(event: EventLog::TWO_STEP_ENABLE_FAILED, uid: @user.uid).count
+      end
+
+      should "accept a valid code, persist the secret and log the event" do
+        enter_code
+
+        assert_response_contains "2-step verification set up"
+        assert_equal @secret, @user.reload.otp_secret_key
+        assert_equal 1, EventLog.where(event: EventLog::TWO_STEP_ENABLED, uid: @user.uid).count
+      end
+    end
+  end
+
+  def enter_code
+    Timecop.freeze do
+      fill_in "code", with: ROTP::TOTP.new(@secret).now
+      click_button "submit_code"
     end
   end
 end


### PR DESCRIPTION
This merges the existing create flow with the update flow, as it’s not
currently possible to add 2SV devices, only replace them. The result is
the update of the user’s OTP key, either from nil to a valid key thus
setting up 2SV, or from an old key to a new one, thus changing the
device they’ve got set up.

The same form is displayed for both cases, the differences are in the
text of the logged event, and the flash messages on success. The flows
are differentiated by the presence of the `otp_secret_key` on the user.

This commit also refactors the controller action responsible for
updating the secret by extracting the logic to verify the entered code
and update the secret.

<img width="743" alt="screen shot 2015-10-09 at 15 50 23" src="https://cloud.githubusercontent.com/assets/18276/10397029/7dd72bdc-6e9d-11e5-8e6d-b61fe1a90eea.png">

/cc @fofr @jamiecobbett @benlovell 