### PR TITLE
Key the 2SV session cookie on a hash of the secret

### DIFF
--- a/app/controllers/devise/two_step_verification_session_controller.rb
+++ b/app/controllers/devise/two_step_verification_session_controller.rb
@@ -11,7 +11,11 @@ class Devise::TwoStepVerificationSessionController < DeviseController
       expires_seconds = User::REMEMBER_2SV_SESSION_FOR
       if expires_seconds && expires_seconds > 0
         cookies.signed['remember_2sv_session'] = {
-          value: {user_id: current_user.id, valid_until: expires_seconds.from_now},
+          value: {
+            user_id: current_user.id,
+            valid_until: expires_seconds.from_now,
+            secret_hash: Digest::SHA256.hexdigest(current_user.otp_secret_key)
+          },
           expires: expires_seconds.from_now
         }
       end

--- a/lib/devise/hooks/two_step_verification.rb
+++ b/lib/devise/hooks/two_step_verification.rb
@@ -1,7 +1,11 @@
 Warden::Manager.after_authentication do |user, auth, _options|
   if user.respond_to?(:need_two_step_verification?)
     cookie = auth.env["action_dispatch.cookies"].signed["remember_2sv_session"]
-    unless cookie && cookie[:user_id] == user.id && cookie[:valid_until] > Time.zone.now
+    valid = cookie &&
+      cookie[:user_id] == user.id &&
+      cookie[:valid_until] > Time.zone.now &&
+      cookie[:secret_hash] == Digest::SHA256.hexdigest(user.otp_secret_key)
+    unless valid
       auth.session(:user)['need_two_step_verification'] = user.need_two_step_verification?
     end
   end

--- a/test/integration/two_step_verification_test.rb
+++ b/test/integration/two_step_verification_test.rb
@@ -5,20 +5,21 @@ require 'helpers/passphrase_support'
 class TwoStepVerificationTest < ActionDispatch::IntegrationTest
   context "setting a 2SV code" do
     setup do
-      @secret = ROTP::Base32.random_base32
-      ROTP::Base32.stubs(random_base32: @secret)
+      @new_secret = ROTP::Base32.random_base32
+      @original_secret = ROTP::Base32.random_base32
+      ROTP::Base32.stubs(random_base32: @new_secret)
     end
 
     context "with an existing 2SV setup" do
       setup do
-        @user = create(:user, email: "jane.user@example.com", otp_secret_key: ROTP::Base32.random_base32)
+        @user = create(:user, email: "jane.user@example.com", otp_secret_key: @original_secret)
         visit new_user_session_path
         signin_with_2sv(@user)
         visit two_step_verification_path
       end
 
       should "show the TOTP secret and a warning" do
-        assert_response_contains "Enter the code manually: #{@secret}"
+        assert_response_contains "Enter the code manually: #{@new_secret}"
         assert_response_contains "Setting up a new phone will replace your existing one. You will only be able to sign in with your new phone."
       end
 
@@ -27,7 +28,7 @@ class TwoStepVerificationTest < ActionDispatch::IntegrationTest
         click_button "submit_code"
 
         assert_response_contains "Sorry that code didn’t work. Please try again."
-        assert_response_contains "Enter the code manually: #{@secret}"
+        assert_response_contains "Enter the code manually: #{@new_secret}"
         assert_equal 1, EventLog.where(event: EventLog::TWO_STEP_CHANGE_FAILED, uid: @user.uid).count
       end
 
@@ -35,8 +36,18 @@ class TwoStepVerificationTest < ActionDispatch::IntegrationTest
         enter_code
 
         assert_response_contains "2-step verification phone changed successfully"
-        assert_equal @secret, @user.reload.otp_secret_key
+        assert_equal @new_secret, @user.reload.otp_secret_key
         assert_equal 1, EventLog.where(event: EventLog::TWO_STEP_CHANGED, uid: @user.uid).count
+      end
+
+      should "require the code again on next login" do
+        enter_code
+
+        within("main") do
+          click_link "Sign out"
+        end
+
+        signin_with_2sv(@user)
       end
     end
 
@@ -49,7 +60,7 @@ class TwoStepVerificationTest < ActionDispatch::IntegrationTest
       end
 
       should "show the TOTP secret" do
-        assert_response_contains "Enter the code manually: #{@secret}"
+        assert_response_contains "Enter the code manually: #{@new_secret}"
       end
 
       should "reject an invalid code, reuse the secret and log the rejection" do
@@ -57,7 +68,7 @@ class TwoStepVerificationTest < ActionDispatch::IntegrationTest
         click_button "submit_code"
 
         assert_response_contains "Sorry that code didn’t work. Please try again."
-        assert_response_contains "Enter the code manually: #{@secret}"
+        assert_response_contains "Enter the code manually: #{@new_secret}"
         assert_equal 1, EventLog.where(event: EventLog::TWO_STEP_ENABLE_FAILED, uid: @user.uid).count
       end
 
@@ -65,7 +76,7 @@ class TwoStepVerificationTest < ActionDispatch::IntegrationTest
         enter_code
 
         assert_response_contains "2-step verification set up"
-        assert_equal @secret, @user.reload.otp_secret_key
+        assert_equal @new_secret, @user.reload.otp_secret_key
         assert_equal 1, EventLog.where(event: EventLog::TWO_STEP_ENABLED, uid: @user.uid).count
       end
     end
@@ -73,7 +84,7 @@ class TwoStepVerificationTest < ActionDispatch::IntegrationTest
 
   def enter_code
     Timecop.freeze do
-      fill_in "code", with: ROTP::TOTP.new(@secret).now
+      fill_in "code", with: ROTP::TOTP.new(@new_secret).now
       click_button "submit_code"
     end
   end


### PR DESCRIPTION
Adding a hash of the secret key into the signed 2SV session cookie
means that if a user changes their 2SV device, they will need to enter
their new code on subsequent logins on all devices.

/cc @benlovell @jamiecobbett @benilovj 