### PR TITLE
Don't try to validate 2SV session cookie if 2SV not enabled

### DIFF
--- a/lib/devise/hooks/two_step_verification.rb
+++ b/lib/devise/hooks/two_step_verification.rb
@@ -1,5 +1,5 @@
 Warden::Manager.after_authentication do |user, auth, _options|
-  if user.respond_to?(:need_two_step_verification?)
+  if user.need_two_step_verification?
     cookie = auth.env["action_dispatch.cookies"].signed["remember_2sv_session"]
     valid = cookie &&
       cookie[:user_id] == user.id &&


### PR DESCRIPTION
Actually check the result of `user.need_two_step_verification?` instead
of checking if we have the method on the user. This was left over from
the `two_factor_authentication` gem’s implementation of the hook, and
wasn’t replaced.

This was causing errors when users had a 2SV session cookie but then
had their secret key reset. Hashing `nil` causes an error. If we check
`need_two_step_verification?` first, we can bypass this.

/cc @jamiecobbett 