### PR TITLE
Bugfix: data-sync-complete job

### DIFF
--- a/lib/tasks/applications.rake
+++ b/lib/tasks/applications.rake
@@ -27,7 +27,7 @@ namespace :applications do
     Doorkeeper::Application.where.not(name: apps_to_ignore).find_each do |application|
       [:redirect_uri, :home_uri].each do |field|
         new_domain = application[field].gsub(ENV['OLD_DOMAIN'], ENV['NEW_DOMAIN'])
-        if application[field] != new_domain
+        unless application[field].include? ENV['NEW_DOMAIN']
           puts "Migrating #{application.name} - #{field} to new domain: #{new_domain}"
           application[field] = new_domain
         end


### PR DESCRIPTION
If this job is run multiple times then redirects risk ending up
incorrect:

```
Migrating Specialist publisher - redirect_uri to new domain:
https://specialist-publisher.staging.staging.publishing.service.gov.uk/auth/gds/callback
```

Note the inclusion of `staging` twice in the URL.

This change seeks to fix that even if the job is run multiple times.