### PR TITLE
Protect the 2SV session controller from unauthed users

### DIFF
--- a/app/controllers/devise/two_step_verification_session_controller.rb
+++ b/app/controllers/devise/two_step_verification_session_controller.rb
@@ -1,4 +1,5 @@
 class Devise::TwoStepVerificationSessionController < DeviseController
+  before_filter { |c| c.authenticate_user! force: true }
   skip_before_action :handle_two_step_verification
 
   def new

--- a/test/integration/sign_in_test.rb
+++ b/test/integration/sign_in_test.rb
@@ -240,4 +240,10 @@ class SignInTest < ActionDispatch::IntegrationTest
     visit root_path
     refute_selector "a", text: "Didn't receive unlock instructions?"
   end
+
+  should "not be able to access the 2SV login page before logging in" do
+    signout
+    visit new_two_step_verification_session_path
+    assert_response_contains("You need to sign in before continuing.")
+  end
 end


### PR DESCRIPTION
This controller wasn’t protected from unauthenticated users, meaning
that if a user landed on the page without a session their
`current_user.authenticate_otp` call would fail, causing an error. The
correct behaviour is to redirect the user to the login path.

We have to use `force: true` in this call because the controller is a
Devise controller, which are excluded from authentication by default.