### PR TITLE
Improve error messaging and track user errors on forms to Google Analytics

### DIFF
--- a/app/helpers/analytics_helper.rb
+++ b/app/helpers/analytics_helper.rb
@@ -1,0 +1,13 @@
+module AnalyticsHelper
+  def analytics_attributes_alert(type, message)
+    safe_message = flash_text_without_email_addresses(message)
+
+    "data-module=\"auto-track-event\"\
+     data-track-action=\"alert-#{type}\"\
+     data-track-label=\"#{safe_message}\"".html_safe
+  end
+
+  def analytics_attributes_alert_danger(message)
+    analytics_attributes_alert('danger', message)
+  end
+end

--- a/app/helpers/analytics_helper.rb
+++ b/app/helpers/analytics_helper.rb
@@ -1,13 +1,9 @@
 module AnalyticsHelper
-  def analytics_attributes_alert(type, message)
-    safe_message = flash_text_without_email_addresses(message)
-
-    "data-module=\"auto-track-event\"\
-     data-track-action=\"alert-#{type}\"\
-     data-track-label=\"#{safe_message}\"".html_safe
-  end
-
-  def analytics_attributes_alert_danger(message)
-    analytics_attributes_alert('danger', message)
+  def track_analytics_data(type, message)
+    {
+      'module' => 'auto-track-event',
+      'track-action' => "alert-#{type}",
+      'track-label' => flash_text_without_email_addresses(message)
+    }
   end
 end

--- a/app/views/devise/password_expired/show.html.erb
+++ b/app/views/devise/password_expired/show.html.erb
@@ -6,12 +6,8 @@
 
 <div class="well">
   <%= form_for(resource, :as => resource_name, :url => [resource_name, :password_expired], :html => { :method => :put }) do |f| %>
-    <%= devise_error_messages! %>
-
+    <%= render partial: "devise/passwords/change_password_errors" %>
     <%= render partial: "devise/passwords/change_password_panel", locals: { f: f, user: resource, updating_password: true } %>
-
-
-    <div><%= f.submit "Change my passphrase", class: "add-top-margin btn btn-primary" %></div>
   <% end %>
 </div>
 

--- a/app/views/devise/passwords/_change_password_errors.html.erb
+++ b/app/views/devise/passwords/_change_password_errors.html.erb
@@ -1,0 +1,12 @@
+<% if resource.errors.count > 0 %>
+  <div class="alert alert-danger">
+    <h3 class="add-bottom-margin remove-top-margin">There was a problem changing your passphrase</h3>
+    <ul>
+      <% resource.errors.full_messages.each do |message| %>
+      <li <%= analytics_attributes_alert_danger(message) %>>
+        <%= message %>
+      </li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/devise/passwords/_change_password_errors.html.erb
+++ b/app/views/devise/passwords/_change_password_errors.html.erb
@@ -3,9 +3,7 @@
     <h3 class="add-bottom-margin remove-top-margin">There was a problem changing your passphrase</h3>
     <ul>
       <% resource.errors.full_messages.each do |message| %>
-      <li <%= analytics_attributes_alert_danger(message) %>>
-        <%= message %>
-      </li>
+        <%= content_tag :li, message, data: track_analytics_data(:danger, message) %>
       <% end %>
     </ul>
   </div>

--- a/app/views/devise/passwords/_change_password_panel.html.erb
+++ b/app/views/devise/passwords/_change_password_panel.html.erb
@@ -64,3 +64,7 @@
     </div>
   </div>
 </div>
+
+<div>
+  <%= f.submit t("users.edit.change"), class: 'btn btn-primary add-top-margin' %>
+</div>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -11,11 +11,9 @@
 
 <div class="well">
   <%= form_for(resource, :as => resource_name, :url => password_path(resource_name), :html => { :method => :put }) do |f| %>
-    <%= devise_error_messages! %>
     <%= f.hidden_field :reset_password_token %>
 
+    <%= render partial: "devise/passwords/change_password_errors" %>
     <%= render partial: "devise/passwords/change_password_panel", locals: { f: f, user: resource } %>
-
-    <div><%= f.submit "Change my passphrase", class: "add-top-margin btn btn-primary" %></div>
   <% end %>
 </div>

--- a/app/views/devise/two_step_verification/show.html.erb
+++ b/app/views/devise/two_step_verification/show.html.erb
@@ -78,9 +78,10 @@
         <div id="step-three" class="panel-collapse collapse <% if invalid_code_entered %>in<% end %>" role="tabpanel" aria-labelledby="step-three-heading">
           <div class="panel-body">
               <% if invalid_code_entered %>
-                <div class="alert alert-danger" <%= analytics_attributes_alert_danger(invalid_code_entered) %>>
-                  <%= invalid_code_entered %>
-                </div>
+                <%= content_tag :div,
+                  invalid_code_entered,
+                  class: 'alert alert-danger',
+                  data: track_analytics_data(:danger, invalid_code_entered) %>
               <% end %>
               <%= form_tag two_step_verification_path, method: :put do %>
                 <%= hidden_field_tag :otp_secret_key, @otp_secret_key%>

--- a/app/views/devise/two_step_verification/show.html.erb
+++ b/app/views/devise/two_step_verification/show.html.erb
@@ -78,7 +78,7 @@
         <div id="step-three" class="panel-collapse collapse <% if invalid_code_entered %>in<% end %>" role="tabpanel" aria-labelledby="step-three-heading">
           <div class="panel-body">
               <% if invalid_code_entered %>
-                <div class="alert alert-danger">
+                <div class="alert alert-danger" <%= analytics_attributes_alert_danger(invalid_code_entered) %>>
                   <%= invalid_code_entered %>
                 </div>
               <% end %>

--- a/app/views/shared/_bootstrap_flash_messages.html.erb
+++ b/app/views/shared/_bootstrap_flash_messages.html.erb
@@ -1,8 +1,6 @@
 <% bootstrap_flash_message_keys.each do |k| %>
-  <div class="alert alert-<%= bootstrap_flash_class(k) %>"
-    data-module="auto-track-event"
-    data-track-action="alert-<%= bootstrap_flash_class(k) %>"
-    data-track-label="<%= flash_text_without_email_addresses(flash[k]) %>">
-      <%= flash[k] %>
-  </div>
+  <%= content_tag :div,
+    flash[k],
+    class: "alert alert-#{bootstrap_flash_class(k)}",
+    data: track_analytics_data(bootstrap_flash_class(k), flash[k]) %>
 <% end %>

--- a/app/views/users/_form_errors.html.erb
+++ b/app/views/users/_form_errors.html.erb
@@ -2,7 +2,9 @@
   <div class="alert alert-danger">
     <ul>
       <% @user.errors.full_messages.each do |message| %>
-      <li><%= message %></li>
+      <li <%= analytics_attributes_alert_danger(message) %>>
+        <%= message %>
+      </li>
       <% end %>
     </ul>
   </div>

--- a/app/views/users/_form_errors.html.erb
+++ b/app/views/users/_form_errors.html.erb
@@ -2,9 +2,7 @@
   <div class="alert alert-danger">
     <ul>
       <% @user.errors.full_messages.each do |message| %>
-      <li <%= analytics_attributes_alert_danger(message) %>>
-        <%= message %>
-      </li>
+        <%= content_tag :li, message, data: track_analytics_data(:danger, message) %>
       <% end %>
     </ul>
   </div>

--- a/app/views/users/edit_email_or_passphrase.html.erb
+++ b/app/views/users/edit_email_or_passphrase.html.erb
@@ -32,7 +32,5 @@
   <h2 class="remove-top-margin"><%= t(".change_passphrase") %></h2>
   <%= form_for current_user, :url => update_passphrase_user_path do |f| %>
     <%= render partial: "devise/passwords/change_password_panel", locals: { f: f, user: current_user, updating_password: true } %>
-
-    <%= f.submit t("users.edit.change"), :class => 'btn btn-primary add-top-margin' %>
   <% end %>
 </section>

--- a/test/helpers/passphrase_support.rb
+++ b/test/helpers/passphrase_support.rb
@@ -13,7 +13,7 @@ module PassPhraseSupport
     fill_in "Current passphrase",       with: from
     fill_in "New passphrase",           with: to
     fill_in "Confirm new passphrase",   with: confirmation
-    click_button "Change my passphrase"
+    click_button "Change passphrase"
   end
 
   def trigger_reset_for(email)
@@ -26,6 +26,6 @@ module PassPhraseSupport
     email.click_link("Change my passphrase")
     fill_in "New passphrase", with: options[:new_password]
     fill_in "Confirm new passphrase", with: options[:new_password]
-    click_button "Change my passphrase"
+    click_button "Change passphrase"
   end
 end

--- a/test/integration/event_log_test.rb
+++ b/test/integration/event_log_test.rb
@@ -62,7 +62,7 @@ class EventLogIntegrationTest < ActionDispatch::IntegrationTest
     token_received_in_email = @user.send_reset_password_instructions
     visit edit_user_password_path(reset_password_token: token_received_in_email)
 
-    click_on "Change my passphrase"
+    click_on "Change passphrase"
 
     assert_equal EventLog::PASSPHRASE_RESET_FAILURE, @user.event_logs.first.event
   end


### PR DESCRIPTION
Collect anonymous metrics on the different types of user error when they’re changing their email or passphrase, or when setting up 2-step verification.

* Add a helper for tracking messages in analytics
* Start tracking the error messages in analytics

This also includes some improvements to the passphrase change forms:

* Avoid using the default devise error message. The default includes a poor heading and old markup. The default can be found here: https://github.com/plataformatec/devise/blob/7df57d5081f9884849ca15e4fde179ef164a575f/app/helpers/devise_helper.rb
* Consolidate errors into a new partial
* DRY up form by moving submit button into partial

## Before
![pasted_image_at_2015_10_08_04_03_pm_720](https://cloud.githubusercontent.com/assets/319055/10727732/05b9064a-7bd4-11e5-8f7e-13820833675c.png)

## After
![screen shot 2015-10-23 at 13 20 58](https://cloud.githubusercontent.com/assets/319055/10727736/0ed30bb8-7bd4-11e5-9780-58157644ccbc.png)

cc @boffbowsh @jamiecobbett