### PR TITLE
Add password reset error to event log

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -43,6 +43,7 @@ private
   end
 
   def record_password_reset_failure(user)
-    EventLog.record_event(user, EventLog::PASSPHRASE_RESET_FAILURE)
+    message = "(errors: #{user.errors.full_messages.join(', ')})".truncate(255)
+    EventLog.record_event(user, EventLog::PASSPHRASE_RESET_FAILURE, trailing_message: message)
   end
 end

--- a/test/integration/event_log_test.rb
+++ b/test/integration/event_log_test.rb
@@ -63,8 +63,11 @@ class EventLogIntegrationTest < ActionDispatch::IntegrationTest
     visit edit_user_password_path(reset_password_token: token_received_in_email)
 
     click_on "Change passphrase"
+    event_log = @user.event_logs.first
 
-    assert_equal EventLog::PASSPHRASE_RESET_FAILURE, @user.event_logs.first.event
+    assert_equal EventLog::PASSPHRASE_RESET_FAILURE, event_log.event
+    assert_match "Passphrase can't be blank", event_log.trailing_message
+    assert_match "Passphrase not strong enough", event_log.trailing_message
   end
 
   test "record successful passphrase change" do


### PR DESCRIPTION
Currently on 2nd line, there's a Zendesk ticket from someone who is having trouble resetting their password:

> it just comes up with the message that I may of used the password before (which I definitely haven’t) or that the link is old even though I have just received the link

We'd like to investigate, but the account access log just displays:

`11:56am, 28 Oct 2015	 Passphrase reset attempt failure`

Which isn't very helpful, as there can be multiple different causes for the user to not be `valid?` ([see the controller](https://github.com/alphagov/signonotron2/blob/c581c8afc4cb09058a3c653c9aa49f604dec2fb6/app/controllers/passwords_controller.rb#L17)). 

By adding the activerecord error messages to `trailing_message` we can get a lot more information and can help users better.

Discuss:

- [x] Good idea?
- [x] Will changing the `trailing_message` type into `text` cause performance issues?
 