### PR TITLE
Resolve attempted unauthenticated access

### DIFF
--- a/app/controllers/devise/two_step_verification_controller.rb
+++ b/app/controllers/devise/two_step_verification_controller.rb
@@ -1,4 +1,5 @@
 class Devise::TwoStepVerificationController < DeviseController
+  before_filter -> { authenticate_user!(force: true) }, only: [:defer, :prompt]
   before_filter :prepare_and_validate, except: [:prompt, :defer]
   skip_before_filter :handle_two_step_verification
 

--- a/test/controllers/two_step_verification_controller_test.rb
+++ b/test/controllers/two_step_verification_controller_test.rb
@@ -9,6 +9,16 @@ class TwoStepVerificationControllerTest < ActionController::TestCase
     sign_in @user
   end
 
+  context 'when an unauthenticated user attempts deferral' do
+    setup { sign_out @user }
+
+    should 'redirect them to login' do
+      put :defer
+
+      assert_redirected_to new_user_session_path
+    end
+  end
+
   context "otp_secret_key_uri" do
     setup do
       @secret = ROTP::Base32.random_base32

--- a/test/controllers/two_step_verification_controller_test.rb
+++ b/test/controllers/two_step_verification_controller_test.rb
@@ -9,11 +9,17 @@ class TwoStepVerificationControllerTest < ActionController::TestCase
     sign_in @user
   end
 
-  context 'when an unauthenticated user attempts deferral' do
+  context 'when unauthenticated' do
     setup { sign_out @user }
 
-    should 'redirect them to login' do
+    should 'redirect to login upon attempted deferral' do
       put :defer
+
+      assert_redirected_to new_user_session_path
+    end
+
+    should 'redirect to login upon attempted prompt' do
+      get :prompt
 
       assert_redirected_to new_user_session_path
     end


### PR DESCRIPTION
This change resolves issues seen in the production environment over the past
few days when a user attempts to defer 2SV, but after their session has
expired.