### PR TITLE
Fix password reset flow

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -21,8 +21,8 @@ class PasswordsController < Devise::PasswordsController
       end
     end
   end
+protected
 
-  protected
   def after_resetting_password_path_for(resource)
     signed_in_root_path(resource)
   end
@@ -37,13 +37,16 @@ private
   end
 
   def record_reset_page_loaded
-    token = Devise.token_generator.digest(self, :reset_password_token, params[:reset_password_token])
-    user_from_params = User.find_by(reset_password_token: token)
     EventLog.record_event(user_from_params, EventLog::PASSPHRASE_RESET_LOADED) if user_from_params
   end
 
   def record_password_reset_failure(user)
     message = "(errors: #{user.errors.full_messages.join(', ')})".truncate(255)
     EventLog.record_event(user, EventLog::PASSPHRASE_RESET_FAILURE, trailing_message: message)
+  end
+
+  def user_from_params
+    token = Devise.token_generator.digest(self, :reset_password_token, params[:reset_password_token])
+    User.find_by(reset_password_token: token)
   end
 end

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -2,6 +2,16 @@ class PasswordsController < Devise::PasswordsController
   before_filter :record_password_reset_request, only: :create
   before_filter :record_reset_page_loaded, only: :edit
 
+  def edit
+    super
+
+    user = user_from_params
+    unless user && user.reset_password_period_valid?
+      render 'devise/passwords/reset_error'
+      return
+    end
+  end
+
   # overrides http://git.io/sOhoaA to prevent expirable from
   # intercepting reset password flow for a partially signed-in user
   def require_no_authentication
@@ -16,11 +26,10 @@ class PasswordsController < Devise::PasswordsController
     super do |resource|
       unless resource.valid?
         record_password_reset_failure(resource) if resource.persisted?
-        render 'devise/passwords/reset_error'
-        return
       end
     end
   end
+
 protected
 
   def after_resetting_password_path_for(resource)

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -8,7 +8,6 @@ class PasswordsController < Devise::PasswordsController
     user = user_from_params
     unless user && user.reset_password_period_valid?
       render 'devise/passwords/reset_error'
-      return
     end
   end
 
@@ -31,15 +30,14 @@ class PasswordsController < Devise::PasswordsController
   end
 
 protected
-
   def after_resetting_password_path_for(resource)
     signed_in_root_path(resource)
   end
 
 private
   def record_password_reset_request
-    user_from_params = User.find_by_email(params[:user][:email]) if params[:user].present?
-    EventLog.record_event(user_from_params, EventLog::PASSPHRASE_RESET_REQUEST) if user_from_params
+    user = User.find_by_email(params[:user][:email]) if params[:user].present?
+    EventLog.record_event(user, EventLog::PASSPHRASE_RESET_REQUEST) if user
     Statsd.new(::STATSD_HOST).increment(
       "#{::STATSD_PREFIX}.users.password_reset_request"
     )

--- a/app/views/devise/passwords/reset_error.html.erb
+++ b/app/views/devise/passwords/reset_error.html.erb
@@ -5,6 +5,6 @@
 </div>
 
 <div class="alert alert-warning">
-  <p>That passphrase reset didn’t work. It may be that you’ve used this passphrase already, or the link you were using has expired or was invalid.</p>
+  <p>That passphrase reset didn’t work. It may be that the link you were using has expired or was invalid.</p>
   <p class="add-top-margin"><%= link_to 'Try again', new_user_password_path, class: 'btn btn-default' %></p>
 </div>

--- a/test/integration/passphrase_reset_test.rb
+++ b/test/integration/passphrase_reset_test.rb
@@ -69,7 +69,7 @@ class PassphraseResetTest < ActionDispatch::IntegrationTest
 
       signout
 
-      complete_password_reset(current_email, new_password: new_password)
+      current_email.click_link("Change my passphrase")
 
       assert_response_contains("That passphrase reset didn’t work.")
     end
@@ -108,5 +108,21 @@ class PassphraseResetTest < ActionDispatch::IntegrationTest
     # partially signed-in user should be able to reset passphrase using link in reset passphrase instructions
     click_link 'Forgot your passphrase?'
     assert_response_contains("Request a passphrase reset")
+  end
+
+  should "show error messages when password reset doesn't work" do
+    perform_enqueued_jobs do
+      user = create(:user)
+      trigger_reset_for(user.email)
+
+      open_email(user.email)
+
+      current_email.click_link("Change my passphrase")
+      fill_in "New passphrase", with: "A Password"
+      fill_in "Confirm new passphrase", with: "Not That Password"
+      click_button "Change passphrase"
+
+      assert_response_contains("Passphrase confirmation doesn't match")
+    end
   end
 end


### PR DESCRIPTION
The password reset flow is currently broken. It should work like this:

1. When users click on a time-expired reset password link, they should see an error message
2. When users click on a previously used or invalid reset password link, they should see an error message
3. When users provide an previously used password, too-weak password or two different passwords, they should see validation errors

Currently there is no validation on the token validity or expiry when the password reset page is loaded, and when the user provides an invalid input, they will see a generic, possibly incorrect error page instead of the password form with errors.

This means users can click on an expired password link and think everything is okay, input a new password and see a message that their link is invalid. Also, users can input an incorrect password and get the message "It may be that you’ve used this passphrase already, or the link you were using has expired or was invalid". We've had several Zendesk requests from people who couldn't change their passwords.

For example: https://govuk.zendesk.com/agent/tickets/1176278

This commit fixes the flow, and updates the integration tests to cover the scenarios.

This commit does not introduce new behaviour, this is the original flow before a change made related to the big Devise upgrade of this summer (930c07c for example).

## Before

![screen shot 2015-11-03 at 10 27 01](https://cloud.githubusercontent.com/assets/233676/10905963/aef946d8-8215-11e5-988c-2bb3290f6582.png)

Visiting the page with an incorrect token.


![screen shot 2015-11-03 at 10 26 53](https://cloud.githubusercontent.com/assets/233676/10905950/a1e5f89c-8215-11e5-97a8-4ce270995e1b.png)

Typing in a too weak password.


## After

![screen shot 2015-11-03 at 10 22 45](https://cloud.githubusercontent.com/assets/233676/10905930/7bab3d86-8215-11e5-8ba5-e1563e6bad06.png)

Visiting the page with an incorrect token.

![screen shot 2015-11-03 at 10 23 39](https://cloud.githubusercontent.com/assets/233676/10905939/900436ca-8215-11e5-8a30-f7a5e15c5dac.png)

Typing in a too-weak password.


/cc @fofr 
