### PR TITLE
Fix 2SV flag notification logic

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -279,7 +279,7 @@ class User < ActiveRecord::Base
   end
 
   def send_two_step_flag_notification?
-    require_2sv? && require_2sv_changed? || two_step_flag_changed?
+    require_2sv? && two_step_flag_changed?
   end
 
 private

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -34,14 +34,6 @@ class UserTest < ActiveSupport::TestCase
         refute @user.reload.send_two_step_flag_notification?
       end
     end
-
-    context 'when the user is flagged' do
-      should 'return true' do
-        @user.require_2sv = true
-
-        assert @user.send_two_step_flag_notification?
-      end
-    end
   end
 
   context '#reset_2sv!' do


### PR DESCRIPTION
Rather than rely on `require_2sv_changed?` (rails' standard dirty
checking for the `require_2sv` attribute) and `two_step_flag_changed?`
(based on `require_2sv_changed?` but can survive persistence
round-tripping) to determine whether to send the flagging notification,
we can simply check - has the user actually been flagged and was the
flag toggled just now?