### PR TITLE
Prompt future admins and superadmins to set up 2SV

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -51,6 +51,7 @@ class User < ActiveRecord::Base
   before_create :generate_uid
   after_create :update_stats
   before_save :mark_two_step_flag_changed
+  before_save :set_2sv_for_admin_roles
 
   scope :web_users, -> { where(api_user: false) }
   scope :not_suspended, -> { where(suspended_at: nil) }
@@ -225,6 +226,11 @@ class User < ActiveRecord::Base
 
   def need_two_step_verification?
     has_2sv?
+  end
+
+  def set_2sv_for_admin_roles
+    return if GovukAdminTemplate.environment_label == "Preview"
+    self.require_2sv = true if role_changed? && (admin? || superadmin?)
   end
 
   def authenticate_otp(code)

--- a/test/integration/admin_user_index_test.rb
+++ b/test/integration/admin_user_index_test.rb
@@ -8,7 +8,7 @@ class AdminUserIndexTest < ActionDispatch::IntegrationTest
 
       @admin = create(:admin_user, name: "Admin User", email: "admin@example.com")
       visit new_user_session_path
-      signin(@admin)
+      signin_with(@admin)
 
       org1 = create(:organisation, name: "Org 1")
       org2 = create(:organisation, name: "Org 2")

--- a/test/integration/authorise_application_test.rb
+++ b/test/integration/authorise_application_test.rb
@@ -12,7 +12,7 @@ class AuthoriseApplicationTest < ActionDispatch::IntegrationTest
       ignoring_spurious_error do
         visit "/oauth/authorize?response_type=code&client_id=#{@app.uid}&redirect_uri=#{@app.redirect_uri}"
       end
-      signin(@user)
+      signin_with(@user, set_up_2sv: false)
     end
 
     should "not confirm the authorisation" do
@@ -36,7 +36,7 @@ class AuthoriseApplicationTest < ActionDispatch::IntegrationTest
     refute Doorkeeper::AccessGrant.find_by(resource_owner_id: @user.id)
 
     ignoring_spurious_error do
-      signin(@user)
+      signin_with(@user)
     end
 
     assert_redirected_to_application @app
@@ -49,7 +49,7 @@ class AuthoriseApplicationTest < ActionDispatch::IntegrationTest
     @user.save!
 
     visit "/"
-    signin(@user)
+    signin_with(@user)
     ignoring_spurious_error do
       visit "/oauth/authorize?response_type=code&client_id=#{@app.uid}&redirect_uri=#{@app.redirect_uri}"
     end
@@ -61,7 +61,7 @@ class AuthoriseApplicationTest < ActionDispatch::IntegrationTest
     @user.update_attribute(:otp_secret_key, ROTP::Base32.random_base32)
 
     visit "/"
-    signin(@user)
+    signin_with(@user, second_step: false)
     ignoring_spurious_error do
       visit "/oauth/authorize?response_type=code&client_id=#{@app.uid}&redirect_uri=#{@app.redirect_uri}"
     end
@@ -71,7 +71,7 @@ class AuthoriseApplicationTest < ActionDispatch::IntegrationTest
 
   should "confirm the authorisation for a signed-in user" do
     visit "/"
-    signin(@user)
+    signin_with(@user)
     ignoring_spurious_error do
       visit "/oauth/authorize?response_type=code&client_id=#{@app.uid}&redirect_uri=#{@app.redirect_uri}"
     end
@@ -84,7 +84,7 @@ class AuthoriseApplicationTest < ActionDispatch::IntegrationTest
     @user.update_attribute(:otp_secret_key, ROTP::Base32.random_base32)
 
     visit "/"
-    signin_with_2sv(@user)
+    signin_with(@user)
     ignoring_spurious_error do
       visit "/oauth/authorize?response_type=code&client_id=#{@app.uid}&redirect_uri=#{@app.redirect_uri}"
     end

--- a/test/integration/batch_inviting_users_test.rb
+++ b/test/integration/batch_inviting_users_test.rb
@@ -8,7 +8,7 @@ class BatchInvitingUsersTest < ActionDispatch::IntegrationTest
       application = create(:application)
       user = create(:user, role: "admin")
       visit root_path
-      signin(user)
+      signin_with(user)
 
       visit new_batch_invitation_path
       path = File.join(::Rails.root, "test", "fixtures", "users.csv")

--- a/test/integration/dashboard_test.rb
+++ b/test/integration/dashboard_test.rb
@@ -5,7 +5,7 @@ class DashboardTest < ActionDispatch::IntegrationTest
   should "notify the user if they've not been assigned any applications" do
     user = create(:user)
     visit root_path
-    signin(user)
+    signin_with(user)
 
     assert_response_contains("Your Applications")
     assert_response_contains("You haven’t been assigned to any applications yet")
@@ -16,7 +16,7 @@ class DashboardTest < ActionDispatch::IntegrationTest
     user = create(:user, with_signin_permissions_for: [app])
 
     visit root_path
-    signin(user)
+    signin_with(user)
 
     assert_response_contains(app.description)
     assert page.has_css?("a[href='#{app.home_uri}']")
@@ -25,7 +25,7 @@ class DashboardTest < ActionDispatch::IntegrationTest
   should "display a link to 2SV setup when flagged" do
     user = create(:two_step_flagged_user)
     visit root_path
-    signin(user)
+    signin_with(user, set_up_2sv: false)
 
     click_button 'Not now'
 

--- a/test/integration/email_change_test.rb
+++ b/test/integration/email_change_test.rb
@@ -16,7 +16,7 @@ class EmailChangeTest < ActionDispatch::IntegrationTest
           user = create(:user)
 
           visit new_user_session_path
-          signin(@admin)
+          signin_with(@admin)
           admin_changes_email_address(user: user, new_email: "new@email.com")
 
           assert_equal "new@email.com", last_email.to[0]
@@ -29,7 +29,7 @@ class EmailChangeTest < ActionDispatch::IntegrationTest
           user = create(:user, email: 'old@email.com')
 
           visit new_user_session_path
-          signin(@admin)
+          signin_with(@admin)
           admin_changes_email_address(user: user, new_email: "new@email.com")
 
           visit event_logs_user_path(user)
@@ -41,7 +41,7 @@ class EmailChangeTest < ActionDispatch::IntegrationTest
         user = create(:user)
 
         visit new_user_session_path
-        signin(@admin)
+        signin_with(@admin)
         admin_changes_email_address(user: user, new_email: "")
 
         assert_response_contains("Email can't be blank")
@@ -59,7 +59,7 @@ class EmailChangeTest < ActionDispatch::IntegrationTest
           assert_equal 'Please confirm your account', current_email.subject
 
           visit new_user_session_path
-          signin(@admin)
+          signin_with(@admin)
           admin_changes_email_address(user: user, new_email: "new@email.com")
 
           email = emails_sent_to("new@email.com").detect { |mail| mail.subject == 'Please confirm your account' }
@@ -80,7 +80,7 @@ class EmailChangeTest < ActionDispatch::IntegrationTest
         original_email = user.email
 
         visit new_user_session_path
-        signin(@admin)
+        signin_with(@admin)
         visit edit_user_path(user)
         click_link "Cancel email change"
         signout
@@ -100,7 +100,7 @@ class EmailChangeTest < ActionDispatch::IntegrationTest
     should "trigger a confirmation email to the user's new address and a notification to the user's old address" do
       perform_enqueued_jobs do
         visit new_user_session_path
-        signin(@user)
+        signin_with(@user)
 
         click_link "Change your email or passphrase"
         fill_in "Email", with: "new@email.com"
@@ -117,7 +117,7 @@ class EmailChangeTest < ActionDispatch::IntegrationTest
     should "log email change events in the user's event log" do
       perform_enqueued_jobs do
         visit new_user_session_path
-        signin(@user)
+        signin_with(@user)
 
         click_link "Change your email or passphrase"
         fill_in "Email", with: "new@email.com"
@@ -126,7 +126,7 @@ class EmailChangeTest < ActionDispatch::IntegrationTest
         first_email_sent_to("new@email.com").click_link("Confirm my account")
 
         signout
-        signin(create(:admin_user))
+        signin_with(create(:admin_user))
         visit event_logs_user_path(@user)
         assert_response_contains "Email change initiated by #{@user.name} from original@email.com to new@email.com"
         assert_response_contains "Email change confirmed"
@@ -135,7 +135,7 @@ class EmailChangeTest < ActionDispatch::IntegrationTest
 
     should "show an error and not send a confirmation if the email is blank" do
       visit new_user_session_path
-      signin(@user)
+      signin_with(@user)
 
       click_link "Change your email or passphrase"
       fill_in "Email", with: ""
@@ -150,7 +150,7 @@ class EmailChangeTest < ActionDispatch::IntegrationTest
       use_javascript_driver
 
       visit new_user_session_path
-      signin(@user)
+      signin_with(@user)
 
       click_link "Change your email or passphrase"
       fill_in "Email", with: "new@email.com"

--- a/test/integration/granting_permissions_test.rb
+++ b/test/integration/granting_permissions_test.rb
@@ -6,7 +6,7 @@ class GrantingPermissionsTest < ActionDispatch::IntegrationTest
     @user = create(:user)
 
     visit root_path
-    signin(@admin)
+    signin_with(@admin)
   end
 
   should "support granting signin permissions" do

--- a/test/integration/inviting_users_test.rb
+++ b/test/integration/inviting_users_test.rb
@@ -8,7 +8,7 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
     should "not display the 2SV flagging checkbox" do
       admin = create(:admin_user)
       visit root_path
-      signin(admin)
+      signin_with(admin)
 
       visit new_user_invitation_path
 
@@ -21,7 +21,7 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
       perform_enqueued_jobs do
         admin = create(:user, role: "admin")
         visit root_path
-        signin(admin)
+        signin_with(admin)
 
         visit new_user_invitation_path
         fill_in "Name", with: "Fred Bloggs"
@@ -48,7 +48,7 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
     should "show an error message when attempting to create a user without an email" do
       admin = create(:user, role: "admin")
       visit root_path
-      signin(admin)
+      signin_with(admin)
 
       visit new_user_invitation_path
       fill_in "Name", with: "Fred Bloggs"
@@ -63,7 +63,7 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
       perform_enqueued_jobs do
         admin = create(:user, role: "superadmin")
         visit root_path
-        signin(admin)
+        signin_with(admin)
 
         visit new_user_invitation_path
         fill_in "Name", with: "Fred Bloggs"
@@ -88,7 +88,7 @@ class InvitingUsersTest < ActionDispatch::IntegrationTest
       perform_enqueued_jobs do
         admin = create(:admin_user)
         visit root_path
-        signin(admin)
+        signin_with(admin)
 
         visit new_user_invitation_path
         assert has_no_select?("Role")

--- a/test/integration/manage_api_users_test.rb
+++ b/test/integration/manage_api_users_test.rb
@@ -7,7 +7,7 @@ class ManageApiUsersTest < ActionDispatch::IntegrationTest
 
       @superadmin = create(:superadmin_user)
       visit new_user_session_path
-      signin(@superadmin)
+      signin_with(@superadmin)
 
       @api_user = create(:api_user, with_permissions: { @application => ["write"] })
       create(:access_token, resource_owner_id: @api_user.id, application_id: @application.id)

--- a/test/integration/passphrase_change_test.rb
+++ b/test/integration/passphrase_change_test.rb
@@ -10,7 +10,7 @@ class PassphraseChangeTest < ActionDispatch::IntegrationTest
       @original_password = "some v3ry s3cure passphrase"
       @user = create(:user, email: "jane.user@example.com", password: @original_password)
       visit new_user_session_path
-      signin(@user)
+      signin_with(@user)
     end
 
     should "change passphrase if the new passphrase is secure enough" do
@@ -66,7 +66,7 @@ class PassphraseChangeTest < ActionDispatch::IntegrationTest
 
       signout
       visit root_path
-      signin(@user)
+      signin_with(@user)
 
       click_link "Change your email or passphrase"
       fill_in "Current passphrase", with: @original_password
@@ -119,7 +119,7 @@ class PassphraseChangeTest < ActionDispatch::IntegrationTest
       original_password = "some v3ry s3cure passphrase"
       @user = create(:admin_user, password: original_password)
       visit new_user_session_path
-      signin(@user)
+      signin_with(@user)
 
       change_password_to("4 totally! dzzzifferent pass-phrase")
 

--- a/test/integration/passphrase_expiry_test.rb
+++ b/test/integration/passphrase_expiry_test.rb
@@ -14,7 +14,7 @@ class PassphraseExpiryTest < ActionDispatch::IntegrationTest
     should "not ask the user to change their password" do
       visit new_user_session_path
 
-      signin(@user)
+      signin_with(@user)
       refute_response_contains(PROMPT_TO_CHANGE_PASSWORD)
     end
   end
@@ -28,7 +28,7 @@ class PassphraseExpiryTest < ActionDispatch::IntegrationTest
     should "force the user to change their password" do
       visit new_user_session_path
 
-      signin(@user)
+      signin_with(@user)
       assert_response_contains(PROMPT_TO_CHANGE_PASSWORD)
 
       reset_expired_passphrase(@user.password, @new_password, @new_password)
@@ -40,7 +40,7 @@ class PassphraseExpiryTest < ActionDispatch::IntegrationTest
     should "remember where the user was trying to get to before the password reset" do
       visit "/users/#{@user.id}/edit_email_or_passphrase?arbitrary=1"
 
-      signin(@user)
+      signin_with(@user)
       reset_expired_passphrase(@user.password, @new_password, @new_password)
 
       assert_current_url "/users/#{@user.id}/edit_email_or_passphrase?arbitrary=1"
@@ -48,7 +48,7 @@ class PassphraseExpiryTest < ActionDispatch::IntegrationTest
 
     should "continue prompting for a new password if an incorrect password was provided" do
       visit new_user_session_path
-      signin(@user)
+      signin_with(@user)
 
       reset_expired_passphrase("nonsense", @new_password, @new_password)
 
@@ -58,7 +58,7 @@ class PassphraseExpiryTest < ActionDispatch::IntegrationTest
 
     should "continue prompting for a new password if the password was not confirmed" do
       visit new_user_session_path
-      signin(@user)
+      signin_with(@user)
 
       reset_expired_passphrase(@user.password, @new_password, "rubbish")
 
@@ -68,7 +68,7 @@ class PassphraseExpiryTest < ActionDispatch::IntegrationTest
 
     should "continue prompting for a new password if the user navigates away from the password reset page" do
       visit new_user_session_path
-      signin(@user)
+      signin_with(@user)
 
       visit new_user_session_path
       assert_response_contains(PROMPT_TO_CHANGE_PASSWORD)

--- a/test/integration/passphrase_reset_test.rb
+++ b/test/integration/passphrase_reset_test.rb
@@ -41,7 +41,7 @@ class PassphraseResetTest < ActionDispatch::IntegrationTest
       trigger_reset_for(user.email)
 
       visit root_path
-      signin(email: user.email, password: user.password)
+      signin_with(email: user.email, password: user.password)
 
       open_email(user.email)
       assert current_email
@@ -103,7 +103,7 @@ class PassphraseResetTest < ActionDispatch::IntegrationTest
     user = create(:user, password_changed_at: 91.days.ago)
 
     visit root_path
-    signin(email: user.email, password: user.password)
+    signin_with(email: user.email, password: user.password)
 
     # partially signed-in user should be able to reset passphrase using link in reset passphrase instructions
     click_link 'Forgot your passphrase?'

--- a/test/integration/session_timeout_test.rb
+++ b/test/integration/session_timeout_test.rb
@@ -10,7 +10,7 @@ class SessionTimeoutTest < ActionDispatch::IntegrationTest
   should "not extend an expired session by viewing the login form" do
     Timecop.freeze((User.timeout_in + 5.minutes).ago) do
       visit root_path
-      signin(email: @user_email, password: @user_password)
+      signin_with(email: @user_email, password: @user_password)
     end
 
     visit "/users/sign_in"

--- a/test/integration/sign_in_test.rb
+++ b/test/integration/sign_in_test.rb
@@ -7,27 +7,27 @@ class SignInTest < ActionDispatch::IntegrationTest
 
   should "display a confirmation for successful sign-ins" do
     visit root_path
-    signin(email: "email@example.com", password: "some passphrase with various $ymb0l$")
+    signin_with(email: "email@example.com", password: "some passphrase with various $ymb0l$")
     assert_response_contains("Signed in successfully.")
   end
 
   should "display a rejection for unsuccessful sign-ins" do
     visit root_path
-    signin(email: "email@example.com", password: "some incorrect passphrase with various $ymb0l$")
+    signin_with(email: "email@example.com", password: "some incorrect passphrase with various $ymb0l$")
     assert_response_contains("Invalid email or passphrase")
   end
 
   should "display the same rejection for failed logins, empty passwords, and missing accounts" do
     visit root_path
-    signin(email: "does-not-exist@example.com", password: "some made up p@ssw0rd")
+    signin_with(email: "does-not-exist@example.com", password: "some made up p@ssw0rd")
     assert_response_contains("Invalid email or passphrase")
 
     visit root_path
-    signin(email: "email@example.com", password: "some incorrect passphrase with various $ymb0l$")
+    signin_with(email: "email@example.com", password: "some incorrect passphrase with various $ymb0l$")
     assert_response_contains("Invalid email or passphrase")
 
     visit root_path
-    signin(email: "email@example.com", password: "")
+    signin_with(email: "email@example.com", password: "")
     assert_response_contains("Invalid email or passphrase")
   end
 
@@ -35,7 +35,7 @@ class SignInTest < ActionDispatch::IntegrationTest
     page.driver.browser.header("Client-IP", "127.0.0.1")
 
     visit root_path
-    signin(email: "email@example.com", password: "some passphrase with various $ymb0l$")
+    signin_with(email: "email@example.com", password: "some passphrase with various $ymb0l$")
     assert_response_contains("Signed in successfully.")
   end
 
@@ -52,7 +52,7 @@ class SignInTest < ActionDispatch::IntegrationTest
 
   should "not remotely sign out user when visiting with an expired session cookie" do
     visit root_path
-    signin(email: "email@example.com", password: "some passphrase with various $ymb0l$")
+    signin_with(email: "email@example.com", password: "some passphrase with various $ymb0l$")
     assert_response_contains("Signed in successfully.")
 
     ReauthEnforcer.expects(:perform_on).never
@@ -60,7 +60,7 @@ class SignInTest < ActionDispatch::IntegrationTest
     Timecop.travel(User.timeout_in + 5.minutes)
 
     visit root_path
-    signin(email: "email@example.com", password: "some passphrase with various $ymb0l$")
+    signin_with(email: "email@example.com", password: "some passphrase with various $ymb0l$")
     assert_response_contains("Signed in successfully.")
   end
 
@@ -71,20 +71,20 @@ class SignInTest < ActionDispatch::IntegrationTest
 
     should "prompt for a verification code" do
       visit root_path
-      signin(email: "email@example.com", password: "some passphrase with various $ymb0l$")
+      signin_with(email: "email@example.com", password: "some passphrase with various $ymb0l$", second_step: false)
       assert_response_contains "get your code"
       assert_selector "input[name=code]"
     end
 
     should "not prompt for a verification code twice per browser in 30 days" do
       visit root_path
-      signin_with_2sv(email: "email@example.com", password: "some passphrase with various $ymb0l$")
+      signin_with(email: "email@example.com", password: "some passphrase with various $ymb0l$")
       assert_response_contains "Welcome to GOV.UK"
 
       signout
       visit root_path
 
-      signin(email: "email@example.com", password: "some passphrase with various $ymb0l$")
+      signin_with(email: "email@example.com", password: "some passphrase with various $ymb0l$", second_step: false)
       assert_response_contains "Welcome to GOV.UK"
 
       signout
@@ -92,14 +92,14 @@ class SignInTest < ActionDispatch::IntegrationTest
 
       Timecop.travel(30.days.from_now + 1) do
         visit root_path
-        signin_with_2sv(email: "email@example.com", password: "some passphrase with various $ymb0l$")
+        signin_with(email: "email@example.com", password: "some passphrase with various $ymb0l$")
         assert_response_contains "Welcome to GOV.UK"
       end
     end
 
     should "prevent access to signon until fully authenticated" do
       visit root_path
-      signin(email: "email@example.com", password: "some passphrase with various $ymb0l$")
+      signin_with(email: "email@example.com", password: "some passphrase with various $ymb0l$", second_step: false)
       visit root_path
       assert_response_contains "get your code"
       assert_selector "input[name=code]"
@@ -107,7 +107,7 @@ class SignInTest < ActionDispatch::IntegrationTest
 
     should "allow access with a correctly-generated code" do
       visit root_path
-      signin_with_2sv(email: "email@example.com", password: "some passphrase with various $ymb0l$")
+      signin_with(email: "email@example.com", password: "some passphrase with various $ymb0l$")
       assert_response_contains "Welcome to GOV.UK"
       assert_response_contains "Signed in successfully"
       assert_equal 1, EventLog.where(event: EventLog::TWO_STEP_VERIFIED, uid: @user.uid).count
@@ -115,11 +115,7 @@ class SignInTest < ActionDispatch::IntegrationTest
 
     should "prevent access with a blank code" do
       visit root_path
-      signin(email: "email@example.com", password: "some passphrase with various $ymb0l$")
-      Timecop.freeze do
-        fill_in :code, with: ""
-        click_button "Sign in"
-      end
+      signin_with(email: "email@example.com", password: "some passphrase with various $ymb0l$", second_step: "")
 
       assert_response_contains "get your code"
       assert_equal 1, EventLog.where(event: EventLog::TWO_STEP_VERIFICATION_FAILED, uid: @user.uid).count
@@ -129,9 +125,7 @@ class SignInTest < ActionDispatch::IntegrationTest
       old_code = Timecop.freeze(2.minutes.ago) { ROTP::TOTP.new(@user.otp_secret_key).now }
 
       visit root_path
-      signin(email: "email@example.com", password: "some passphrase with various $ymb0l$")
-      fill_in :code, with: old_code
-      click_button "Sign in"
+      signin_with(email: "email@example.com", password: "some passphrase with various $ymb0l$", second_step: old_code)
 
       assert_response_contains "get your code"
       assert_equal 1, EventLog.where(event: EventLog::TWO_STEP_VERIFICATION_FAILED, uid: @user.uid).count
@@ -139,9 +133,7 @@ class SignInTest < ActionDispatch::IntegrationTest
 
     should "prevent access with a garbage code" do
       visit root_path
-      signin(email: "email@example.com", password: "some passphrase with various $ymb0l$")
-      fill_in :code, with: "abcdef"
-      click_button "Sign in"
+      signin_with(email: "email@example.com", password: "some passphrase with various $ymb0l$", second_step: "abcdef")
 
       assert_response_contains "get your code"
       assert_equal 1, EventLog.where(event: EventLog::TWO_STEP_VERIFICATION_FAILED, uid: @user.uid).count
@@ -149,7 +141,7 @@ class SignInTest < ActionDispatch::IntegrationTest
 
     should "prevent access if max attempts reached" do
       visit root_path
-      signin(email: "email@example.com", password: "some passphrase with various $ymb0l$")
+      signin_with(email: "email@example.com", password: "some passphrase with various $ymb0l$", second_step: false)
 
       Timecop.freeze do
         User::MAX_2SV_LOGIN_ATTEMPTS.times do
@@ -165,7 +157,7 @@ class SignInTest < ActionDispatch::IntegrationTest
 
     should "not permit an expired cookie to be used to bypass 2SV" do
       visit root_path
-      signin_with_2sv(email: "email@example.com", password: "some passphrase with various $ymb0l$")
+      signin_with(email: "email@example.com", password: "some passphrase with various $ymb0l$")
       remember_2sv_session = Capybara.current_session.driver.request.cookies["remember_2sv_session"]
 
       Timecop.travel(30.days.from_now + 1) do
@@ -175,7 +167,7 @@ class SignInTest < ActionDispatch::IntegrationTest
         Capybara.current_session.driver.request.cookies["remember_2sv_session"] = remember_2sv_session
 
         visit root_path
-        signin(email: "email@example.com", password: "some passphrase with various $ymb0l$")
+        signin_with(email: "email@example.com", password: "some passphrase with various $ymb0l$", second_step: false)
         assert_response_contains "get your code"
         assert_selector "input[name=code]"
       end
@@ -186,12 +178,12 @@ class SignInTest < ActionDispatch::IntegrationTest
       attacker.update_attribute(:otp_secret_key, ROTP::Base32.random_base32)
 
       visit root_path
-      signin_with_2sv(email: "attacker@example.com", password: "c0mpl£x $ymb0l$")
+      signin_with(email: "attacker@example.com", password: "c0mpl£x $ymb0l$")
       remember_2sv_session = Capybara.current_session.driver.request.cookies["remember_2sv_session"]
       signout
 
       visit root_path
-      signin(email: "email@example.com", password: "some passphrase with various $ymb0l$")
+      signin_with(email: "email@example.com", password: "some passphrase with various $ymb0l$", second_step: false)
       Capybara.current_session.driver.request.cookies["remember_2sv_session"] = remember_2sv_session
       visit root_path
       assert_response_contains "get your code"
@@ -200,14 +192,14 @@ class SignInTest < ActionDispatch::IntegrationTest
 
     should "not remember a user's 2SV session if they've changed 2SV secret" do
       visit root_path
-      signin_with_2sv(email: "email@example.com", password: "some passphrase with various $ymb0l$")
+      signin_with(email: "email@example.com", password: "some passphrase with various $ymb0l$")
       assert_response_contains "Welcome to GOV.UK"
 
       signout
       visit root_path
 
       @user.update_attribute(:otp_secret_key, ROTP::Base32.random_base32)
-      signin(email: "email@example.com", password: "some passphrase with various $ymb0l$")
+      signin_with(email: "email@example.com", password: "some passphrase with various $ymb0l$", second_step: false)
 
       assert_response_contains "get your code"
       assert_selector "input[name=code]"
@@ -215,21 +207,21 @@ class SignInTest < ActionDispatch::IntegrationTest
 
     should "not prevent login if 2SV is disabled for user with a remembered session" do
       visit root_path
-      signin_with_2sv(email: "email@example.com", password: "some passphrase with various $ymb0l$")
+      signin_with(email: "email@example.com", password: "some passphrase with various $ymb0l$")
       assert_response_contains "Welcome to GOV.UK"
 
       signout
       visit root_path
 
       @user.update_attribute(:otp_secret_key, nil)
-      signin(email: "email@example.com", password: "some passphrase with various $ymb0l$")
+      signin_with(email: "email@example.com", password: "some passphrase with various $ymb0l$", second_step: false)
 
       assert_response_contains "Signed in successfully"
     end
 
     should "allow the user to cancel 2SV by signing out" do
       visit root_path
-      signin(email: "email@example.com", password: "some passphrase with various $ymb0l$")
+      signin_with(email: "email@example.com", password: "some passphrase with various $ymb0l$", second_step: false)
       click_link "Sign out"
 
       assert_text "Signed out successfully."

--- a/test/integration/sign_out_test.rb
+++ b/test/integration/sign_out_test.rb
@@ -7,7 +7,7 @@ class SignOutTest < ActionDispatch::IntegrationTest
   end
 
   should "perform reauth on downstream apps" do
-    signin(@user)
+    signin_with(@user)
     ReauthEnforcer.expects(:perform_on).with(@user).once
 
     within("main") do

--- a/test/integration/super_admin_flagging_two_step_verification_test.rb
+++ b/test/integration/super_admin_flagging_two_step_verification_test.rb
@@ -9,7 +9,7 @@ class SuperAdminFlaggingTwoStepVerificationTest < ActionDispatch::IntegrationTes
       super_admin = create(:superadmin_user)
       user = create(:user)
       visit root_path
-      signin(super_admin)
+      signin_with(super_admin)
 
       visit edit_user_path(user)
     end

--- a/test/integration/super_admin_reset_two_step_verification_test.rb
+++ b/test/integration/super_admin_reset_two_step_verification_test.rb
@@ -13,7 +13,7 @@ class SuperAdminResetTwoStepVerificationTest < ActionDispatch::IntegrationTest
       @admin = create(:admin_user)
 
       visit edit_user_path(@user)
-      signin(@admin)
+      signin_with(@admin)
     end
 
     should 'not display the link' do
@@ -27,7 +27,7 @@ class SuperAdminResetTwoStepVerificationTest < ActionDispatch::IntegrationTest
 
       use_javascript_driver
       visit edit_user_path(@user)
-      signin(@super_admin)
+      signin_with(@super_admin)
     end
 
     should 'reset 2-step verification and notify the chosen user by email' do

--- a/test/integration/superadmin_application_edit_test.rb
+++ b/test/integration/superadmin_application_edit_test.rb
@@ -9,7 +9,7 @@ class SuperAdminApplicationEditTest < ActionDispatch::IntegrationTest
 
       @superadmin = create(:superadmin_user)
       visit new_user_session_path
-      signin(@superadmin)
+      signin_with(@superadmin)
       within("ul.nav") do
         click_link "Applications"
       end

--- a/test/integration/two_step_verification_prompt_test.rb
+++ b/test/integration/two_step_verification_prompt_test.rb
@@ -5,7 +5,7 @@ class TwoStepVerificationPromptTest < ActionDispatch::IntegrationTest
     setup do
       @user = create(:two_step_flagged_user)
       visit users_path
-      signin(@user)
+      signin_with(@user, set_up_2sv: false)
     end
 
     should 'prompt the user to complete verification' do

--- a/test/integration/two_step_verification_test.rb
+++ b/test/integration/two_step_verification_test.rb
@@ -16,7 +16,7 @@ class TwoStepVerificationTest < ActionDispatch::IntegrationTest
       setup do
         @user = create(:user, email: "jane.user@example.com", otp_secret_key: @original_secret)
         visit new_user_session_path
-        signin_with_2sv(@user)
+        signin_with(@user)
         visit two_step_verification_path
       end
 
@@ -54,15 +54,15 @@ class TwoStepVerificationTest < ActionDispatch::IntegrationTest
           click_link "Sign out"
         end
 
-        signin_with_2sv(@user)
+        signin_with(@user)
       end
     end
 
     context "for a user without an existing 2SV setup" do
       setup do
-        @user = create(:admin_user, email: "jane.user@example.com")
-        visit users_path
-        signin(@user)
+        @user = create(:user, email: "jane.user@example.com")
+        visit root_path
+        signin_with(@user)
         visit two_step_verification_path
       end
 

--- a/test/integration/user_link_test.rb
+++ b/test/integration/user_link_test.rb
@@ -5,7 +5,7 @@ class UserLinkTest < ActionDispatch::IntegrationTest
     setup do
       @admin = create(:admin_user, name: "Adam Adminson", email: "admin@example.com")
       visit new_user_session_path
-      signin(@admin)
+      signin_with(@admin)
     end
 
     should "link to the current user's edit page" do

--- a/test/integration/user_locking_test.rb
+++ b/test/integration/user_locking_test.rb
@@ -7,9 +7,9 @@ class UserLockingTest < ActionDispatch::IntegrationTest
     perform_enqueued_jobs do
       user = create(:user)
       visit root_path
-      8.times { signin(email: user.email, password: "wrong password") }
+      8.times { signin_with(email: user.email, password: "wrong password") }
 
-      signin(user)
+      signin_with(user)
 
       assert_equal user.email, last_email.to[0]
       assert_equal "Your GOV.UK Signon development account has been locked", last_email.subject
@@ -26,7 +26,7 @@ class UserLockingTest < ActionDispatch::IntegrationTest
     visit root_path
 
     assert_enqueued_jobs(1) do
-      8.times { signin(email: user.email, password: "wrong password") }
+      8.times { signin_with(email: user.email, password: "wrong password") }
     end
   end
 
@@ -36,7 +36,7 @@ class UserLockingTest < ActionDispatch::IntegrationTest
     user.lock_access!
 
     visit root_path
-    signin(admin)
+    signin_with(admin)
     first_letter_of_name = user.name[0]
     visit users_path(letter: first_letter_of_name)
     click_button 'Unlock account'
@@ -51,7 +51,7 @@ class UserLockingTest < ActionDispatch::IntegrationTest
     user.lock_access!
 
     visit root_path
-    signin(admin)
+    signin_with(admin)
     visit edit_user_path(user)
 
     click_button 'Unlock account'

--- a/test/integration/user_status_test.rb
+++ b/test/integration/user_status_test.rb
@@ -11,7 +11,7 @@ class UserStatusTest < ActionDispatch::IntegrationTest
 
   test "User status appears on the edit user page" do
     visit root_path
-    signin @admin
+    signin_with(@admin)
     visit user_path(@user)
 
     assert page.has_content?("User passphrase expired")

--- a/test/integration/user_suspension_test.rb
+++ b/test/integration/user_suspension_test.rb
@@ -8,7 +8,7 @@ class UserSuspensionTest < ActionDispatch::IntegrationTest
 
   should "prevent users from signing in" do
     visit new_user_session_path
-    signin(@user)
+    signin_with(@user)
 
     assert_response_contains("account has been suspended")
   end
@@ -16,7 +16,7 @@ class UserSuspensionTest < ActionDispatch::IntegrationTest
   should "show the suspension reason to admins" do
     admin = create(:user, role: 'admin')
     visit new_user_session_path
-    signin(admin)
+    signin_with(admin)
 
     visit edit_user_path(@user)
     assert_response_contains("gross misconduct")

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -32,6 +32,16 @@ require 'helpers/confirmation_token_helper'
 class ActionController::TestCase
   include Devise::TestHelpers
   include ConfirmationTokenHelper
+
+  def sign_in(user)
+    warden.stubs(authenticate!: user)
+    @controller.stubs(current_user: user)
+  end
+
+  def sign_out(user)
+    warden.unstub(:authenticate!)
+    @controller.unstub(:current_user)
+  end
 end
 
 require 'capybara/rails'


### PR DESCRIPTION
https://trello.com/c/Xh7kLY4z/150-prompting-all-current-and-future-admins-and-super-admins-to-set-up-2sv-in-production-only-small

When a user is promoted to an admin or superadmin, they should have the `require_2sv` flag set.

This new behaviour caused a lot of tests to break, so first the test authentication helpers were refactored to make this transition easier.

Best reviewed commit-by-commit.