### PR TITLE
Allow time drift when setting up 2SV

### DIFF
--- a/app/controllers/devise/two_step_verification_controller.rb
+++ b/app/controllers/devise/two_step_verification_controller.rb
@@ -71,7 +71,7 @@ class Devise::TwoStepVerificationController < DeviseController
   def verify_code_and_update
     @otp_secret_key = params[:otp_secret_key]
     totp = ROTP::TOTP.new(@otp_secret_key)
-    if totp.verify(params[:code])
+    if totp.verify_with_drift(params[:code], User::MAX_2SV_DRIFT_SECONDS)
       current_user.update_attribute(:otp_secret_key, @otp_secret_key)
       true
     else

--- a/test/integration/two_step_verification_test.rb
+++ b/test/integration/two_step_verification_test.rb
@@ -94,7 +94,7 @@ class TwoStepVerificationTest < ActionDispatch::IntegrationTest
       end
 
       should "accept a valid code from a device which has a small time lag" do
-        old_code = Timecop.freeze(35.seconds.ago) { ROTP::TOTP.new(@new_secret).now }
+        old_code = Timecop.freeze(29.seconds.ago) { ROTP::TOTP.new(@new_secret).now }
 
         Timecop.freeze do
           fill_in "code", with: old_code

--- a/test/integration/two_step_verification_test.rb
+++ b/test/integration/two_step_verification_test.rb
@@ -92,6 +92,17 @@ class TwoStepVerificationTest < ActionDispatch::IntegrationTest
           assert SUCCESS, last_email.subject
         end
       end
+
+      should "accept a valid code from a device which has a small time lag" do
+        old_code = Timecop.freeze(35.seconds.ago) { ROTP::TOTP.new(@new_secret).now }
+
+        Timecop.freeze do
+          fill_in "code", with: old_code
+          click_button "submit_code"
+        end
+
+        assert_response_contains "2-step verification set up"
+      end
     end
   end
 end


### PR DESCRIPTION
When you sign in, we allow codes from devices which have a time which lags
behind the time on the server. This is because user devices are frequently
not automatically updated with the correct time.

This fixes a bug where we didn't allow codes from such devices at setup time.