### PR TITLE
Ensure users are emailed about 2SV on promotion

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,8 +50,8 @@ class User < ActiveRecord::Base
   before_validation :fix_apostrophe_in_email
   before_create :generate_uid
   after_create :update_stats
-  before_save :mark_two_step_flag_changed
   before_save :set_2sv_for_admin_roles
+  before_save :mark_two_step_flag_changed
 
   scope :web_users, -> { where(api_user: false) }
   scope :not_suspended, -> { where(suspended_at: nil) }

--- a/app/views/devise/two_step_verification/prompt.html.erb
+++ b/app/views/devise/two_step_verification/prompt.html.erb
@@ -9,7 +9,7 @@
 <%= form_tag defer_two_step_verification_path, method: :put do %>
 <div class="panel panel-default">
   <div class="panel-body">
-    <p class="lead">Make your signon account more secure by setting up 2-step verification. You’ll need to install an app on your phone which will generate a security code to enter when you sign in.</p>
+    <p class="lead">Make your signon account more secure by setting up 2&#8209;step verification. You’ll need to install an app on your phone which will generate a security code to enter when you sign in.</p>
     <p class="lead remove-bottom-margin">Set up takes about 5 minutes.</p>
   </div>
   <div class="panel-footer" data-module="track-click">

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -70,6 +70,14 @@ class UserTest < ActiveSupport::TestCase
           assert @user.send_two_step_flag_notification?
         end
       end
+
+      context "when promoting a user" do
+        should "be true" do
+          @user.update_attribute(:role, "admin")
+
+          assert @user.send_two_step_flag_notification?
+        end
+      end
     end
 
     context 'when already flagged' do


### PR DESCRIPTION
The trigger for sending an email is the `require_2sv` flag turning
true, captured by the `mark_two_step_flag_changed` callback. Setting
`require_2sv` first for admin and superadmin promotion means the
notification flag is set correctly.
