### PR TITLE
Run `EventLog` validations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,7 @@ group :test do
   gem 'database_cleaner', '1.5.0'
   gem 'factory_girl_rails', '~> 4.5.0'
   gem 'mocha', '1.1.0', require: false
-  gem 'webmock', '1.17.3'
+  gem 'webmock', '1.22.3'
   gem 'minitest', '~> 5.8.0'
   gem 'ci_reporter', '1.7.0'
   gem 'timecop', '0.7.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,6 +175,7 @@ GEM
       bootstrap-sass (~> 3.3.3)
       jquery-rails (~> 3.1.3)
       rails (>= 3.2.0)
+    hashdiff (0.2.3)
     hitimes (1.2.3)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
@@ -360,9 +361,10 @@ GEM
       macaddr (~> 1.0)
     warden (1.2.3)
       rack (>= 1.0)
-    webmock (1.17.3)
-      addressable (>= 2.2.7)
+    webmock (1.22.3)
+      addressable (>= 2.3.6)
       crack (>= 0.3.2)
+      hashdiff
     websocket-driver (0.6.2)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -425,7 +427,7 @@ DEPENDENCIES
   uglifier (= 2.7.1)
   unicorn (= 4.9.0)
   uuid
-  webmock (= 1.17.3)
+  webmock (= 1.22.3)
   whenever (~> 0.9.4)
   zeroclipboard-rails
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -114,6 +114,7 @@ class UsersController < ApplicationController
 
   def update_passphrase
     if @user.update_with_password(password_params)
+      EventLog.record_event(@user, EventLog::SUCCESSFUL_PASSPHRASE_CHANGE)
       flash[:notice] = t(:updated, scope: 'devise.passwords')
       sign_in(@user, bypass: true)
       redirect_to root_path

--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -1,6 +1,4 @@
 class EventLog < ActiveRecord::Base
-  include ActiveModel::ForbiddenAttributesProtection
-
   LOCKED_DURATION = "#{Devise.unlock_in / 1.hour} #{'hour'.pluralize(Devise.unlock_in / 1.hour)}"
 
   ACCOUNT_LOCKED = "Passphrase verification failed too many times, account locked for #{LOCKED_DURATION}"

--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -55,7 +55,7 @@ class EventLog < ActiveRecord::Base
 
   def self.record_event(user, event, options = {})
     attributes = { uid: user.uid, event: event }.merge!(options.slice(*VALID_OPTIONS))
-    EventLog.create(attributes)
+    EventLog.create!(attributes)
   end
 
   def self.record_email_change(user, email_was, email_is, initiator = user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -49,7 +49,7 @@ class User < ActiveRecord::Base
   belongs_to :organisation
 
   before_validation :fix_apostrophe_in_email
-  before_create :generate_uid
+  after_initialize :generate_uid
   after_create :update_stats
   before_save :set_2sv_for_admin_roles
   before_save :mark_two_step_flag_changed
@@ -116,7 +116,7 @@ class User < ActiveRecord::Base
   end
 
   def generate_uid
-    self.uid = UUID.generate
+    self.uid ||= UUID.generate
   end
 
   def invited_but_not_accepted
@@ -306,13 +306,6 @@ private
   def mark_two_step_flag_changed
     @two_step_flag_changed = require_2sv_changed?
     true
-  end
-
-  # Override devise_security_extension for updating expired passwords
-  def update_password_changed
-    super.tap do |result|
-      EventLog.record_event(self, EventLog::SUCCESSFUL_PASSPHRASE_CHANGE) if result
-    end
   end
 
   def organisation_admin_belongs_to_organisation


### PR DESCRIPTION
These validations were being silently ignored. To workaround the broken
behaviour we generate the `uid` earlier in the lifecycle, ensure
validations fail loudly via `create!` and move the event logging for
'successful passphrase change' to the correct place.

Once the `uid` was being set (thus passing validation) this event was being
logged continually, whereas before it would fail silently.