### PR TITLE
Log and persist events by ID

### DIFF
--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -1,60 +1,73 @@
 class EventLog < ActiveRecord::Base
   LOCKED_DURATION = "#{Devise.unlock_in / 1.hour} #{'hour'.pluralize(Devise.unlock_in / 1.hour)}"
 
-  ACCOUNT_LOCKED = "Passphrase verification failed too many times, account locked for #{LOCKED_DURATION}"
-  ACCOUNT_SUSPENDED = "Account suspended"
-  ACCOUNT_UNSUSPENDED = "Account unsuspended"
-  ACCOUNT_AUTOSUSPENDED = "Account auto-suspended"
-  MANUAL_ACCOUNT_UNLOCK = "Manual account unlock"
-  PASSPHRASE_EXPIRED = "Passphrase expired"
-  PASSPHRASE_RESET_REQUEST = "Passphrase reset request"
-  PASSPHRASE_RESET_LOADED = "Passphrase reset page loaded"
-  PASSPHRASE_RESET_FAILURE = "Passphrase reset attempt failure"
-  SUCCESSFUL_PASSPHRASE_CHANGE = "Successful passphrase change"
-  SUCCESSFUL_LOGIN = "Successful login"
-  UNSUCCESSFUL_LOGIN = "Unsuccessful login"
-  SUSPENDED_ACCOUNT_AUTHENTICATED_LOGIN = "Unsuccessful login attempt to a suspended account, with the correct username and password"
-  UNSUCCESSFUL_PASSPHRASE_CHANGE = "Unsuccessful passphrase change"
-  EMAIL_CHANGED = "Email changed"
-  EMAIL_CHANGE_INITIATED = "Email change initiated"
-  EMAIL_CHANGE_CONFIRMED = "Email change confirmed"
-  TWO_STEP_ENABLED = "2-step verification enabled"
-  TWO_STEP_RESET = "2-step verification reset"
-  TWO_STEP_ENABLE_FAILED = "2-step verification setup failed"
-  TWO_STEP_VERIFIED = "2-step verification successful"
-  TWO_STEP_VERIFICATION_FAILED = "2-step verification failed"
-  TWO_STEP_LOCKED = "2-step verification failed too many times, account locked for #{LOCKED_DURATION}"
-  TWO_STEP_CHANGED = "2-step verification phone changed"
-  TWO_STEP_CHANGE_FAILED = "2-step verification phone change failed"
-  TWO_STEP_PROMPT_DEFERRED = "2-step prompt deferred"
+  EVENTS = [
+    ACCOUNT_LOCKED                        = LogEntry.new(id: 1, description: "Passphrase verification failed too many times, account locked for #{LOCKED_DURATION}"),
+    ACCOUNT_SUSPENDED                     = LogEntry.new(id: 2, description: "Account suspended", require_initiator: true),
+    ACCOUNT_UNSUSPENDED                   = LogEntry.new(id: 3, description: "Account unsuspended", require_initiator: true),
+    ACCOUNT_AUTOSUSPENDED                 = LogEntry.new(id: 4, description: "Account auto-suspended"),
+    MANUAL_ACCOUNT_UNLOCK                 = LogEntry.new(id: 5, description: "Manual account unlock", require_initiator: true),
+    PASSPHRASE_EXPIRED                    = LogEntry.new(id: 6, description: "Passphrase expired"),
+    PASSPHRASE_RESET_REQUEST              = LogEntry.new(id: 7, description: "Passphrase reset request"),
+    PASSPHRASE_RESET_LOADED               = LogEntry.new(id: 8, description: "Passphrase reset page loaded"),
+    PASSPHRASE_RESET_FAILURE              = LogEntry.new(id: 9, description: "Passphrase reset attempt failure"),
+    SUCCESSFUL_PASSPHRASE_CHANGE          = LogEntry.new(id: 10, description: "Successful passphrase change"),
+    SUCCESSFUL_LOGIN                      = LogEntry.new(id: 11, description: "Successful login"),
+    UNSUCCESSFUL_LOGIN                    = LogEntry.new(id: 12, description: "Unsuccessful login"),
+    SUSPENDED_ACCOUNT_AUTHENTICATED_LOGIN = LogEntry.new(id: 13, description: "Unsuccessful login attempt to a suspended account, with the correct username and password"),
+    UNSUCCESSFUL_PASSPHRASE_CHANGE        = LogEntry.new(id: 14, description: "Unsuccessful passphrase change"),
+    EMAIL_CHANGED                         = LogEntry.new(id: 15, description: "Email changed", require_initiator: true),
+    EMAIL_CHANGE_INITIATED                = LogEntry.new(id: 16, description: "Email change initiated"),
+    EMAIL_CHANGE_CONFIRMED                = LogEntry.new(id: 17, description: "Email change confirmed"),
+    TWO_STEP_ENABLED                      = LogEntry.new(id: 18, description: "2-step verification enabled"),
+    TWO_STEP_RESET                        = LogEntry.new(id: 19, description: "2-step verification reset"),
+    TWO_STEP_ENABLE_FAILED                = LogEntry.new(id: 20, description: "2-step verification setup failed"),
+    TWO_STEP_VERIFIED                     = LogEntry.new(id: 21, description: "2-step verification successful"),
+    TWO_STEP_VERIFICATION_FAILED          = LogEntry.new(id: 22, description: "2-step verification failed"),
+    TWO_STEP_LOCKED                       = LogEntry.new(id: 23, description: "2-step verification failed too many times, account locked for #{LOCKED_DURATION}"),
+    TWO_STEP_CHANGED                      = LogEntry.new(id: 24, description: "2-step verification phone changed"),
+    TWO_STEP_CHANGE_FAILED                = LogEntry.new(id: 25, description: "2-step verification phone change failed"),
+    TWO_STEP_PROMPT_DEFERRED              = LogEntry.new(id: 26, description: "2-step prompt deferred"),
+    API_USER_CREATED                      = LogEntry.new(id: 27, description: "Account created", require_initiator: true),
+    ACCESS_TOKEN_REGENERATED              = LogEntry.new(id: 28, description: "Access token re-generated", require_application: true),
+    ACCESS_TOKEN_GENERATED                = LogEntry.new(id: 29, description: "Access token generated", require_application: true, require_initiator: true),
+    ACCESS_TOKEN_REVOKED                  = LogEntry.new(id: 30, description: "Access token revoked", require_application: true, require_initiator: true),
+  ]
 
-  # API users
-  API_USER_CREATED = "Account created"
-  ACCESS_TOKEN_REGENERATED = "Access token re-generated"
-  ACCESS_TOKEN_GENERATED = "Access token generated"
-  ACCESS_TOKEN_REVOKED = "Access token revoked"
+  EVENTS_REQUIRING_INITIATOR   = EVENTS.select(&:require_initiator?)
+  EVENTS_REQUIRING_APPLICATION = EVENTS.select(&:require_application?)
 
-  EVENTS_REQUIRING_INITIATOR = [ACCOUNT_SUSPENDED,
-                                ACCOUNT_UNSUSPENDED,
-                                MANUAL_ACCOUNT_UNLOCK,
-                                API_USER_CREATED,
-                                ACCESS_TOKEN_GENERATED,
-                                ACCESS_TOKEN_REVOKED,
-                                EMAIL_CHANGED]
-
-  EVENTS_REQUIRING_APPLICATION_ID = [ACCESS_TOKEN_REGENERATED, ACCESS_TOKEN_GENERATED, ACCESS_TOKEN_REVOKED]
   VALID_OPTIONS = [:initiator, :application, :trailing_message]
 
   validates :uid, presence: true
   validates :event, presence: true
-  validates_presence_of :initiator_id, if: Proc.new { |event_log| EVENTS_REQUIRING_INITIATOR.include? event_log.event }
-  validates_presence_of :application_id, if: Proc.new { |event_log| EVENTS_REQUIRING_APPLICATION_ID.include? event_log.event }
+  validates_presence_of :event_id
+  validate :validate_event_mappable, if: :event_id?
+  validates_presence_of :initiator_id,   if: Proc.new { |event_log| EVENTS_REQUIRING_INITIATOR.include? event_log.entry }
+  validates_presence_of :application_id, if: Proc.new { |event_log| EVENTS_REQUIRING_APPLICATION.include? event_log.entry }
 
   belongs_to :initiator, class_name: "User"
   belongs_to :application, class_name: "Doorkeeper::Application"
 
+  def event
+    if event_id? && entry
+      entry.description
+    else
+      super
+    end
+  end
+
+  def entry
+    EVENTS.detect { |event| event.id == event_id }
+  end
+
   def self.record_event(user, event, options = {})
-    attributes = { uid: user.uid, event: event }.merge!(options.slice(*VALID_OPTIONS))
+    attributes = {
+      uid: user.uid,
+      event_id: event.id,
+      event: event.description
+    }.merge!(options.slice(*VALID_OPTIONS))
+
     EventLog.create!(attributes)
   end
 
@@ -65,5 +78,12 @@ class EventLog < ActiveRecord::Base
 
   def self.for(user)
     EventLog.order('created_at DESC').where(uid: user.uid)
+  end
+
+private
+  def validate_event_mappable
+    unless entry
+      errors.add(:event_id, "must have a corresponding `LogEntry` for #{event_id}")
+    end
   end
 end

--- a/app/models/log_entry.rb
+++ b/app/models/log_entry.rb
@@ -1,0 +1,18 @@
+class LogEntry
+  attr_reader :id, :description
+
+  def initialize(id:, description:, require_initiator: false, require_application: false)
+    @id = id
+    @description = description
+    @require_initiator = require_initiator
+    @require_application = require_application
+  end
+
+  def require_initiator?
+    @require_initiator
+  end
+
+  def require_application?
+    @require_application
+  end
+end

--- a/db/migrate/20151112110911_add_event_id_to_event_logs.rb
+++ b/db/migrate/20151112110911_add_event_id_to_event_logs.rb
@@ -1,0 +1,5 @@
+class AddEventIdToEventLogs < ActiveRecord::Migration
+  def change
+    add_column :event_logs, :event_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151006091244) do
+ActiveRecord::Schema.define(version: 20151112110911) do
 
   create_table "batch_invitation_application_permissions", force: :cascade do |t|
     t.integer  "batch_invitation_id",     limit: 4, null: false
@@ -51,6 +51,7 @@ ActiveRecord::Schema.define(version: 20151006091244) do
     t.integer  "initiator_id",     limit: 4
     t.integer  "application_id",   limit: 4
     t.string   "trailing_message", limit: 255
+    t.integer  "event_id",         limit: 4
   end
 
   add_index "event_logs", ["uid", "created_at"], name: "index_event_logs_on_uid_and_created_at", using: :btree

--- a/test/controllers/confirmations_controller_test.rb
+++ b/test/controllers/confirmations_controller_test.rb
@@ -63,7 +63,7 @@ class ConfirmationsControllerTest < ActionController::TestCase
 
       should "log an event upon confirmation" do
         get :show, confirmation_token: @confirmation_token
-        assert_equal 1, EventLog.where(event: EventLog::EMAIL_CHANGE_CONFIRMED, uid: @user.uid).count
+        assert_equal 1, EventLog.where(event_id: EventLog::EMAIL_CHANGE_CONFIRMED.id, uid: @user.uid).count
       end
     end
 
@@ -95,7 +95,7 @@ class ConfirmationsControllerTest < ActionController::TestCase
       put :update,
             confirmation_token: @confirmation_token,
             user: { password: "this 1s 4 v3333ry s3cur3 p4ssw0rd.!Z" }
-      assert_equal 1, EventLog.where(event: EventLog::EMAIL_CHANGE_CONFIRMED, uid: @user.uid).count
+      assert_equal 1, EventLog.where(event_id: EventLog::EMAIL_CHANGE_CONFIRMED.id, uid: @user.uid).count
     end
 
     should "reject with an incorrect token" do

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -93,7 +93,7 @@ class UsersControllerTest < ActionController::TestCase
 
       should "log an event" do
         put :update_email, id: @user.id, user: { email: "new@email.com" }
-        assert_equal 1, EventLog.where(event: EventLog::EMAIL_CHANGE_INITIATED, uid: @user.uid, initiator_id: @user.id).count
+        assert_equal 1, EventLog.where(event_id: EventLog::EMAIL_CHANGE_INITIATED.id, uid: @user.uid, initiator_id: @user.id).count
       end
     end
   end
@@ -562,7 +562,7 @@ class UsersControllerTest < ActionController::TestCase
           normal_user = create(:user, email: "old@email.com")
           put :update, id: normal_user.id, user: { email: "new@email.com" }
 
-          assert_equal 1, EventLog.where(event: EventLog::EMAIL_CHANGED, uid: normal_user.uid, initiator_id: @user.id).count
+          assert_equal 1, EventLog.where(event_id: EventLog::EMAIL_CHANGED.id, uid: normal_user.uid, initiator_id: @user.id).count
         end
 
         should "send email change notifications to old and new email address" do

--- a/test/integration/sign_in_test.rb
+++ b/test/integration/sign_in_test.rb
@@ -110,7 +110,7 @@ class SignInTest < ActionDispatch::IntegrationTest
       signin_with(email: "email@example.com", password: "some passphrase with various $ymb0l$")
       assert_response_contains "Welcome to GOV.UK"
       assert_response_contains "Signed in successfully"
-      assert_equal 1, EventLog.where(event: EventLog::TWO_STEP_VERIFIED, uid: @user.uid).count
+      assert_equal 1, EventLog.where(event_id: EventLog::TWO_STEP_VERIFIED.id, uid: @user.uid).count
     end
 
     should "prevent access with a blank code" do
@@ -118,7 +118,7 @@ class SignInTest < ActionDispatch::IntegrationTest
       signin_with(email: "email@example.com", password: "some passphrase with various $ymb0l$", second_step: "")
 
       assert_response_contains "get your code"
-      assert_equal 1, EventLog.where(event: EventLog::TWO_STEP_VERIFICATION_FAILED, uid: @user.uid).count
+      assert_equal 1, EventLog.where(event_id: EventLog::TWO_STEP_VERIFICATION_FAILED.id, uid: @user.uid).count
     end
 
     should "prevent access with an old code" do
@@ -128,7 +128,7 @@ class SignInTest < ActionDispatch::IntegrationTest
       signin_with(email: "email@example.com", password: "some passphrase with various $ymb0l$", second_step: old_code)
 
       assert_response_contains "get your code"
-      assert_equal 1, EventLog.where(event: EventLog::TWO_STEP_VERIFICATION_FAILED, uid: @user.uid).count
+      assert_equal 1, EventLog.where(event_id: EventLog::TWO_STEP_VERIFICATION_FAILED.id, uid: @user.uid).count
     end
 
     should "prevent access with a garbage code" do
@@ -136,7 +136,7 @@ class SignInTest < ActionDispatch::IntegrationTest
       signin_with(email: "email@example.com", password: "some passphrase with various $ymb0l$", second_step: "abcdef")
 
       assert_response_contains "get your code"
-      assert_equal 1, EventLog.where(event: EventLog::TWO_STEP_VERIFICATION_FAILED, uid: @user.uid).count
+      assert_equal 1, EventLog.where(event_id: EventLog::TWO_STEP_VERIFICATION_FAILED.id, uid: @user.uid).count
     end
 
     should "prevent access if max attempts reached" do
@@ -152,7 +152,7 @@ class SignInTest < ActionDispatch::IntegrationTest
         assert_response_contains 1.hour.from_now.to_s(:govuk_time)
       end
       assert_response_contains "entered too many times"
-      assert_equal 1, EventLog.where(event: EventLog::TWO_STEP_LOCKED, uid: @user.uid).count
+      assert_equal 1, EventLog.where(event_id: EventLog::TWO_STEP_LOCKED.id, uid: @user.uid).count
     end
 
     should "not permit an expired cookie to be used to bypass 2SV" do

--- a/test/integration/two_step_verification_test.rb
+++ b/test/integration/two_step_verification_test.rb
@@ -31,7 +31,7 @@ class TwoStepVerificationTest < ActionDispatch::IntegrationTest
 
         assert_response_contains "Sorry that code didn’t work. Please try again."
         assert_response_contains "Enter the code manually: #{@new_secret}"
-        assert_equal 1, EventLog.where(event: EventLog::TWO_STEP_CHANGE_FAILED, uid: @user.uid).count
+        assert_equal 1, EventLog.where(event_id: EventLog::TWO_STEP_CHANGE_FAILED.id, uid: @user.uid).count
       end
 
       should "accept a valid code, persist the secret and log the event" do
@@ -40,7 +40,7 @@ class TwoStepVerificationTest < ActionDispatch::IntegrationTest
 
           assert_response_contains "2-step verification phone changed successfully"
           assert_equal @new_secret, @user.reload.otp_secret_key
-          assert_equal 1, EventLog.where(event: EventLog::TWO_STEP_CHANGED, uid: @user.uid).count
+          assert_equal 1, EventLog.where(event_id: EventLog::TWO_STEP_CHANGED.id, uid: @user.uid).count
 
           assert last_email
           assert "Your 2-step verification phone has been changed", last_email.subject
@@ -76,7 +76,7 @@ class TwoStepVerificationTest < ActionDispatch::IntegrationTest
 
         assert_response_contains "Sorry that code didn’t work. Please try again."
         assert_response_contains "Enter the code manually: #{@new_secret}"
-        assert_equal 1, EventLog.where(event: EventLog::TWO_STEP_ENABLE_FAILED, uid: @user.uid).count
+        assert_equal 1, EventLog.where(event_id: EventLog::TWO_STEP_ENABLE_FAILED.id, uid: @user.uid).count
       end
 
       should "accept a valid code, persist the secret, log an event and notify by email" do
@@ -86,7 +86,7 @@ class TwoStepVerificationTest < ActionDispatch::IntegrationTest
 
           assert_response_contains SUCCESS
           assert_equal @new_secret, @user.reload.otp_secret_key
-          assert_equal 1, EventLog.where(event: EventLog::TWO_STEP_ENABLED, uid: @user.uid).count
+          assert_equal 1, EventLog.where(event_id: EventLog::TWO_STEP_ENABLED.id, uid: @user.uid).count
 
           assert last_email
           assert SUCCESS, last_email.subject

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -105,7 +105,7 @@ class UserTest < ActiveSupport::TestCase
 
     should 'record the event' do
       assert_equal 1, EventLog.where(
-        event: EventLog::TWO_STEP_RESET,
+        event_id: EventLog::TWO_STEP_RESET.id,
         uid: @two_step_user.uid,
         initiator: @super_admin
       ).count
@@ -163,7 +163,7 @@ class UserTest < ActiveSupport::TestCase
     end
 
     should 'record an event' do
-      assert_equal 1, EventLog.where(event: EventLog::TWO_STEP_PROMPT_DEFERRED, uid: @user.uid).count
+      assert_equal 1, EventLog.where(event_id: EventLog::TWO_STEP_PROMPT_DEFERRED.id, uid: @user.uid).count
     end
   end
 


### PR DESCRIPTION
Trello: https://trello.com/c/zjBz0vTu

Declare and persist events by identifiers, rather than by their string
representations.

These changes will allow the `event_id` and `event` attributes/columns
to coexist until such time a migration is ran to convert the existing
`event` column values to their respective `event_id`s.

Some of the changes to support this:

* Override `event` reader and attempt to map message via `EVENTS`
* Add the `event_id` attribute for persistence
* Default `event` to an empty string so it is no longer mandatory
* Don't validate `event` when an `event_id` is provided
* Fixup broken specs that referred to the `event` directly
* Removed a redundant spec that was well covered elsewhere
* Validate presence of `event_id`
* Ensure `event_id` corresponds with `EVENTS` entry

A follow-up PR is due shortly to populate the `event_id`s of existing rows via
mapping from the `event`. After this we can dispense with the `event` column.