### PR TITLE
Populate `event_id` attributes from existing events

### DIFF
--- a/lib/event_id_populator.rb
+++ b/lib/event_id_populator.rb
@@ -1,0 +1,7 @@
+class EventIdPopulator
+  def self.populate
+    EventLog::EVENTS.each do |event|
+      EventLog.where(event: event.description, event_id: nil).update_all(event_id: event.id)
+    end
+  end
+end

--- a/lib/tasks/event_logs.rake
+++ b/lib/tasks/event_logs.rake
@@ -14,4 +14,13 @@ namespace :event_logs do
       puts "All events were mapped"
     end
   end
+
+  desc 'Fix remaining `event_id`s for renamed entries'
+  task fix_remaining_event_ids: :environment do
+    events = EventLog.where(event_id: nil, event: 'Account locked')
+    puts "Updating #{events.size} events"
+
+    events.update_all(event_id: EventLog::ACCOUNT_LOCKED.id)
+    puts "All events were mapped"
+  end
 end

--- a/lib/tasks/event_logs.rake
+++ b/lib/tasks/event_logs.rake
@@ -1,0 +1,17 @@
+namespace :event_logs do
+  desc 'Populate `event_id` from mapped `event`'
+  task populate_event_ids: :environment do
+    puts "Updating #{EventLog.where(event_id: nil).size} events"
+
+    EventIdPopulator.populate
+
+    remaining = EventLog.where(event_id: nil).pluck(:event).uniq
+
+    if remaining.present?
+      puts "Some events could not be mapped:"
+      puts remaining
+    else
+      puts "All events were mapped"
+    end
+  end
+end

--- a/test/integration/populate_event_ids_test.rb
+++ b/test/integration/populate_event_ids_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+
+class PopulateEventIdsTest < ActionDispatch::IntegrationTest
+  context 'for a bunch of events without `event_id`' do
+    setup do
+      user = create(:user)
+
+      event_types = [
+        EventLog::TWO_STEP_ENABLED,
+        EventLog::SUCCESSFUL_LOGIN,
+        EventLog::UNSUCCESSFUL_LOGIN,
+        EventLog::TWO_STEP_RESET,
+      ]
+
+      @events = event_types.map do |event|
+        EventLog.new(uid: user.uid, event: event.description).tap do |event|
+          # save these in the state they are in production
+          # i.e. without an associated `event_id`
+          event.save(validate: false)
+        end
+      end
+    end
+
+    should 'accurately populate the `event_id` attribute' do
+      EventIdPopulator.populate
+
+      @events.map(&:reload).each do |event|
+        # ensure this won't fall back on the persisted attribute
+        event.event = nil
+
+        assert_equal event.event, event.entry.description
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is based on #438.

Simple rake tasks to populate the newly created `event_id` column via mappings from `event`.