### PR TITLE
Auto-flag adminish users for 2SV in production only

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -4,7 +4,7 @@ class UserMailer < Devise::Mailer
 
   default from: Proc.new { email_from }
 
-  helper_method :suspension_time, :account_name, :instance_name, :locked_time, :unlock_time, :preview?
+  helper_method :suspension_time, :account_name, :instance_name, :locked_time, :unlock_time, :production?
 
   def two_step_reset(user)
     @user = user
@@ -17,7 +17,7 @@ class UserMailer < Devise::Mailer
   end
 
   def two_step_enabled(user)
-    prefix = "[PREVIEW] " if preview?
+    prefix = "[#{Rails.application.config.instance_name.titleize}] " unless production?
     @user = user
     mail(to: @user.email, subject: "#{prefix}2-step verification set up")
   end
@@ -92,7 +92,7 @@ private
       default: [:subject, key.to_s.humanize], app_name: app_name)
   end
 
-  def preview?
-    GovukAdminTemplate.environment_label == "Preview"
+  def production?
+    Rails.application.config.instance_name.blank?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -238,7 +238,7 @@ class User < ActiveRecord::Base
   end
 
   def set_2sv_for_admin_roles
-    return if GovukAdminTemplate.environment_label == "Preview"
+    return if Rails.application.config.instance_name.present?
     self.require_2sv = true if role_changed? && (admin? || superadmin?)
   end
 

--- a/app/views/user_mailer/two_step_enabled.html.erb
+++ b/app/views/user_mailer/two_step_enabled.html.erb
@@ -4,7 +4,7 @@
 account more secure. Next time you sign in, you’ll need the phone you used
 during set up.</p>
 
-<% if preview? %>
+<% unless production? %>
 <p>You’ll have to set up 2-step verification separately for your Production
 account.</p>
 <% end %>

--- a/app/views/user_mailer/two_step_enabled.text.erb
+++ b/app/views/user_mailer/two_step_enabled.text.erb
@@ -2,7 +2,7 @@ Hello <%= @user.name %>,
 
 You’ve successfully set up 2-step verification. This will make your Signon account more secure. Next time you sign in, you’ll need the phone you used during set up.
 
-<% if preview? %>
+<% unless production? %>
 You’ll have to set up 2-step verification separately for your Production account.
 <% end %>
 

--- a/test/integration/two_step_verification_prompt_test.rb
+++ b/test/integration/two_step_verification_prompt_test.rb
@@ -1,36 +1,6 @@
 require 'test_helper'
 
 class TwoStepVerificationPromptTest < ActionDispatch::IntegrationTest
-  context 'for an admin user that has not been flagged' do
-    setup do
-      @user = create(:admin_user)
-    end
-
-    context 'before the 2SV hard go live date' do
-      should 'display the go live disclaimer' do
-        travel_to User::TWO_STEP_GO_LIVE_DATE - 1 do
-          visit users_path
-          signin_with(@user, set_up_2sv: false)
-
-          assert page.has_text?('From Friday 20 November')
-        end
-      end
-    end
-
-    context 'after the 2SV hard go live date' do
-      should 'not permit deferral or display go live disclaimer' do
-        travel_to User::TWO_STEP_GO_LIVE_DATE do
-          visit users_path
-          signin_with(@user, set_up_2sv: false)
-
-          assert page.has_link?('Start set up')
-          assert page.has_no_button?('Not now')
-          assert page.has_no_text?('From Friday 20 November')
-        end
-      end
-    end
-  end
-
   context 'when the user has been flagged for 2-step verification' do
     setup do
       @user = create(:two_step_flagged_user)
@@ -70,6 +40,30 @@ class TwoStepVerificationPromptTest < ActionDispatch::IntegrationTest
         enter_2sv_code(secret)
 
         assert_equal users_path, current_path
+      end
+    end
+
+    context 'before the 2SV hard go live date' do
+      should 'display the go live disclaimer' do
+        travel_to User::TWO_STEP_GO_LIVE_DATE - 1 do
+          visit users_path
+          signin_with(@user, set_up_2sv: false)
+
+          assert page.has_text?('From Friday 20 November')
+        end
+      end
+    end
+
+    context 'after the 2SV hard go live date' do
+      should 'not permit deferral or display go live disclaimer' do
+        travel_to User::TWO_STEP_GO_LIVE_DATE do
+          visit users_path
+          signin_with(@user, set_up_2sv: false)
+
+          assert page.has_link?('Start set up')
+          assert page.has_no_button?('Not now')
+          assert page.has_no_text?('From Friday 20 November')
+        end
       end
     end
   end

--- a/test/models/user_mailer_test.rb
+++ b/test/models/user_mailer_test.rb
@@ -19,13 +19,13 @@ class UserMailerTest < ActionMailer::TestCase
       @email = UserMailer.two_step_enabled(user)
     end
 
-    context "in the preview environment" do
+    context "in a non-production environment" do
       setup do
-        GovukAdminTemplate.stubs(environment_label: "Preview")
+        Rails.application.config.stubs(instance_name: "foobar")
       end
 
-      should "include [PREVIEW] in the subject" do
-        assert_includes @email.subject, "[PREVIEW]"
+      should "include the environment in the subject" do
+        assert_includes @email.subject, "[Foobar]"
       end
 
       should "include the 'verify for production separately' warning" do
@@ -33,9 +33,13 @@ class UserMailerTest < ActionMailer::TestCase
       end
     end
 
-    context "in other environments" do
-      should "not include [PREVIEW] in the subject" do
-        assert_not_includes @email.subject, "[PREVIEW]"
+    context "in the production environment" do
+      setup do
+        Rails.application.config.stubs(instance_name: nil)
+      end
+
+      should "not include the environment in the subject" do
+        refute_match /^\[/, @email.subject
       end
 
       should "not include the 'verify for production separately' warning" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -5,6 +5,8 @@ class UserTest < ActiveSupport::TestCase
   include ActiveJob::TestHelper
 
   def setup
+    Rails.application.config.stubs(instance_name: nil)
+
     @user = create(:user)
   end
 
@@ -13,13 +15,13 @@ class UserTest < ActiveSupport::TestCase
       refute create(:user).require_2sv?
     end
 
-    should "default to true for admins and superadmins" do
+    should "default to true for admins and superadmins in production" do
       assert create(:admin_user).require_2sv?
       assert create(:superadmin_user).require_2sv?
     end
 
-    should "default to false for admins and superadmins in preview" do
-      GovukAdminTemplate.stubs(environment_label: "Preview")
+    should "default to false for admins and superadmins in non-production" do
+      Rails.application.config.stubs(instance_name: "foobar")
 
       refute create(:admin_user).require_2sv?
       refute create(:superadmin_user).require_2sv?


### PR DESCRIPTION
https://trello.com/c/2xcA8uQT/173-change-preview-only-2sv-and-wider-signon-behaviour-to-include-new-integration-environment

A new integration environment is being introduced to eventually replace
preview, so logic is being switched to only auto-flag users in
production environment.

This behaviour should eventually be controlled by a specific
configuration variable in line with 12 factor, but we need to get this
updated quickly in order to work with the new environment.

Additionally, this now depends on `instance_name` directly in line with
other logic in this app. For production, `instance_name` is `nil`.