### PR TITLE
Nokogiri 1.6.6.5 pre release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,8 @@ gem 'alphabetical_paginate', '2.2.3'
 gem 'mysql2', '0.3.20'
 gem 'govuk_admin_template', '3.3.1'
 
+gem 'nokogiri', github: "alphagov/nokogiri", branch: "v1.6.6.5.rc"
+
 gem 'airbrake', '3.1.15'
 gem 'plek', '1.7.0'
 gem 'json', '1.8.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: git://github.com/alphagov/nokogiri.git
+  revision: 597dd3bb86df337b310bf22c8224884c9fc5161a
+  branch: v1.6.6.5.rc
+  specs:
+    nokogiri (1.6.6.5.20151124112525)
+      mini_portile (~> 0.6.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -217,8 +225,6 @@ GEM
     mysql2 (0.3.20)
     nenv (0.2.0)
     netrc (0.10.3)
-    nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
     null_logger (0.0.1)
     orm_adapter (0.5.0)
     parser (2.2.3.0)
@@ -407,6 +413,7 @@ DEPENDENCIES
   minitest (~> 5.8.0)
   mocha (= 1.1.0)
   mysql2 (= 0.3.20)
+  nokogiri!
   plek (= 1.7.0)
   poltergeist (= 1.6.0)
   pry-byebug


### PR DESCRIPTION
This builds against an unofficial hacked-together release branch of nokogiri: https://github.com/sparklemotion/nokogiri/compare/v1.6.6.4...alphagov:v1.6.6.5.rc#diff-6ec7138703b74a4663177519781472b6

Addresses the security vulnerabilities in libxml2 by vendoring v2.9.3. Release announcement: http://www.xmlsoft.org/bugs.html

Similar PRs exist in alphagov/whitehall#2389, alphagov/static#679 and alphagov/frontend#898