### PR TITLE
Add deprecated columns macro

### DIFF
--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -1,4 +1,7 @@
 class EventLog < ActiveRecord::Base
+  extend DeprecatedColumns
+  deprecated_columns :event
+
   LOCKED_DURATION = "#{Devise.unlock_in / 1.hour} #{'hour'.pluralize(Devise.unlock_in / 1.hour)}"
 
   EVENTS = [

--- a/config/initializers/warn_on_unguarded_column_removals.rb
+++ b/config/initializers/warn_on_unguarded_column_removals.rb
@@ -1,0 +1,25 @@
+module ActiveRecord::ConnectionAdapters::SchemaStatements
+  def remove_column_with_column_warning(table_name, column_name, type = nil, options = {})
+    puts column_deprecation_status(table_name, column_name)
+    remove_column_without_column_warning(table_name, column_name, type, options)
+  end
+
+  alias_method_chain :remove_column, :column_warning
+
+  def column_deprecation_status(table_name, column_name)
+    begin
+      klass = table_name.to_s.singularize.camelize.constantize
+    rescue NameError
+      return "WARNING: Couldn't find model for table #{table_name}. I can't tell " +
+        "if column #{column_name} has been deprecated."
+    end
+
+    if klass.try(:deprecated_column_list).to_a.include?(column_name.to_s)
+      "OK: #{table_name}.#{column_name} has been deprecated."
+    else
+      "WARNING: #{table_name}.#{column_name} has not been deprecated. Please " +
+        "use the `DeprecatedColumns` mixin to avoid crashing Whitehall in " +
+        "production."
+    end
+  end
+end

--- a/lib/deprecated_columns.rb
+++ b/lib/deprecated_columns.rb
@@ -1,0 +1,25 @@
+module DeprecatedColumns
+  # This is here to enable us to gracefully remove columns
+  # in a future commit, *after* the code marking the column
+  # as deprecated has been deployed
+  def deprecated_columns(*names)
+    unless self.respond_to?(:deprecated_column_list)
+      class_attribute :deprecated_column_list
+      self.deprecated_column_list = []
+    end
+
+    self.deprecated_column_list += names.map(&:to_s)
+
+    include InstanceMethods
+  end
+
+  def columns
+    super.reject { |column| deprecated_column_list.include?(column.name) }
+  end
+
+  module InstanceMethods
+    def attribute_names
+      super.reject { |name| deprecated_column_list.include?(name) }
+    end
+  end
+end

--- a/test/db/warn_on_unguarded_column_removals_test.rb
+++ b/test/db/warn_on_unguarded_column_removals_test.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+
+class ModelWithoutDeprecation
+end
+
+class ModelWithDeprecation
+  extend DeprecatedColumns
+  deprecated_columns :my_column
+end
+
+class WarnOnColumnRemovalTest < ActiveSupport::TestCase
+  def test_remove_column_without_deprecation
+    out = message_for(:model_without_deprecation, :title)
+
+    assert out.starts_with? "WARNING: model_without_deprecation.title has not been deprecated"
+  end
+
+  def test_remove_column_from_non_existing_table
+    out = message_for(:does_not_exist, :title)
+
+    assert out.starts_with? "WARNING: Couldn't find model for table does_not_exist."
+  end
+
+  def test_remove_column_with_deprecation
+    out = message_for(:model_with_deprecation, :my_column)
+
+    assert out.starts_with? "OK: model_with_deprecation.my_column has been deprecated."
+  end
+
+  def message_for(table_name, column_name)
+    # ActiveRecord::Migration wraps `say_with_time` around all method calls, but
+    # we don't want that output in test-mode.
+    silence_stream $stdout do
+      ActiveRecord::Migration.new.column_deprecation_status(table_name, column_name)
+    end
+  end
+end


### PR DESCRIPTION
Adds the deprecated columns macro from alphagov/whitehall. This allows
a grace period when making subtractive schema changes.

I'll come back and extract this behaviour into a gem to be reused from both
this application and alphagov/whitehall.