### PR TITLE
Use stable version of Nokogiri

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'alphabetical_paginate', '2.2.3'
 gem 'mysql2', '0.3.20'
 gem 'govuk_admin_template', '3.3.1'
 
-gem 'nokogiri', github: "alphagov/nokogiri", branch: "v1.6.6.5.rc"
+gem 'nokogiri', '~> 1.6.6.4'
 
 gem 'airbrake', '3.1.15'
 gem 'plek', '1.7.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: git://github.com/alphagov/nokogiri.git
-  revision: 597dd3bb86df337b310bf22c8224884c9fc5161a
-  branch: v1.6.6.5.rc
-  specs:
-    nokogiri (1.6.6.5.20151124112525)
-      mini_portile (~> 0.6.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -225,6 +217,8 @@ GEM
     mysql2 (0.3.20)
     nenv (0.2.0)
     netrc (0.10.3)
+    nokogiri (1.6.6.4)
+      mini_portile (~> 0.6.0)
     null_logger (0.0.1)
     orm_adapter (0.5.0)
     parser (2.2.3.0)
@@ -413,7 +407,7 @@ DEPENDENCIES
   minitest (~> 5.8.0)
   mocha (= 1.1.0)
   mysql2 (= 0.3.20)
-  nokogiri!
+  nokogiri (~> 1.6.6.4)
   plek (= 1.7.0)
   poltergeist (= 1.6.0)
   pry-byebug


### PR DESCRIPTION
Nokogiri will be cutting an official release soon after more testing. This
hacked together release is causing some developers issues with building
Nokogiri, and the security vulnerabilities are no longer thought to be too
severe. Whilst we wait for an official release, we should revert as far as the
most recent stable release, 1.6.6.4, as this does address some security
vulnerabilites.