### PR TITLE
Upgrade Nokogiri to 1.6.6.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,8 @@ gem 'alphabetical_paginate', '2.2.3'
 gem 'mysql2', '0.3.20'
 gem 'govuk_admin_template', '3.3.1'
 
+gem 'nokogiri', '~> 1.6.6.4'
+
 gem 'airbrake', '3.1.15'
 gem 'plek', '1.7.0'
 gem 'json', '1.8.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -217,7 +217,7 @@ GEM
     mysql2 (0.3.20)
     nenv (0.2.0)
     netrc (0.10.3)
-    nokogiri (1.6.6.2)
+    nokogiri (1.6.6.4)
       mini_portile (~> 0.6.0)
     null_logger (0.0.1)
     orm_adapter (0.5.0)
@@ -407,6 +407,7 @@ DEPENDENCIES
   minitest (~> 5.8.0)
   mocha (= 1.1.0)
   mysql2 (= 0.3.20)
+  nokogiri (~> 1.6.6.4)
   plek (= 1.7.0)
   poltergeist (= 1.6.0)
   pry-byebug


### PR DESCRIPTION
This addresses vulnerabilities in libxml2:

CVE-2015-1819
CVE-2015-7941_1
CVE-2015-7941_2
CVE-2015-7942
CVE-2015-7942-2
CVE-2015-8035
CVE-2015-7995