### PR TITLE
Remove `event` column

### DIFF
--- a/db/migrate/20151203161459_remove_event_column.rb
+++ b/db/migrate/20151203161459_remove_event_column.rb
@@ -1,0 +1,5 @@
+class RemoveEventColumn < ActiveRecord::Migration
+  def change
+    remove_column :event_logs, :event
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151202120153) do
+ActiveRecord::Schema.define(version: 20151203161459) do
 
   create_table "batch_invitation_application_permissions", force: :cascade do |t|
     t.integer  "batch_invitation_id",     limit: 4, null: false
@@ -45,13 +45,12 @@ ActiveRecord::Schema.define(version: 20151202120153) do
   add_index "batch_invitations", ["outcome"], name: "index_batch_invitations_on_outcome", using: :btree
 
   create_table "event_logs", force: :cascade do |t|
-    t.string   "uid",              limit: 255,              null: false
-    t.datetime "created_at",                                null: false
+    t.string   "uid",              limit: 255, null: false
+    t.datetime "created_at",                   null: false
     t.integer  "initiator_id",     limit: 4
     t.integer  "application_id",   limit: 4
     t.string   "trailing_message", limit: 255
     t.integer  "event_id",         limit: 4
-    t.string   "event",            limit: 255, default: "", null: false
   end
 
   add_index "event_logs", ["uid", "created_at"], name: "index_event_logs_on_uid_and_created_at", using: :btree


### PR DESCRIPTION
Removes the now redundant `event` column, as this has been superseded by
the `event_id` and virtual `event` attribute and mapping.

/cc @benlovell 