### PR TITLE
Allow superadmins to see users for app

### DIFF
--- a/app/controllers/doorkeeper_applications_controller.rb
+++ b/app/controllers/doorkeeper_applications_controller.rb
@@ -17,6 +17,11 @@ class DoorkeeperApplicationsController < ApplicationController
     end
   end
 
+  def users_with_access
+    authorized_users_user_ids = @application.authorized_tokens.select(:resource_owner_id)
+    @users = policy_scope(User).where(id: authorized_users_user_ids).includes(:organisation).page(params[:page]).per(100)
+  end
+
   private
 
   def load_and_authorize_application

--- a/app/controllers/doorkeeper_applications_controller.rb
+++ b/app/controllers/doorkeeper_applications_controller.rb
@@ -18,7 +18,11 @@ class DoorkeeperApplicationsController < ApplicationController
   end
 
   def users_with_access
-    authorized_users_user_ids = @application.authorized_tokens.select(:resource_owner_id)
+    authorized_users_user_ids = UserApplicationPermission.where(
+      supported_permission: @application.signin_permission,
+      application: @application
+    ).select(:user_id)
+
     @users = policy_scope(User).where(id: authorized_users_user_ids).includes(:organisation).page(params[:page]).per(100)
   end
 

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -5,4 +5,5 @@ class ApplicationPolicy < BasePolicy
   alias_method :edit?, :index?
   alias_method :update?, :index?
   alias_method :manage_supported_permissions?, :index?
+  alias_method :users_with_access?, :index?
 end

--- a/app/views/doorkeeper_applications/edit.html.erb
+++ b/app/views/doorkeeper_applications/edit.html.erb
@@ -9,6 +9,10 @@
   <h1>Edit application &ldquo;<%= @application.name %>&rdquo;</h1>
 </div>
 
+<p>
+  <%= link_to "Users with access", users_with_access_doorkeeper_application_path(@application) %>
+</p>
+
 <%= form_for @application, :html => {:class => 'well'} do |f| %>
 
   <% if @application.errors.count > 0 %>

--- a/app/views/doorkeeper_applications/users_with_access.html.erb
+++ b/app/views/doorkeeper_applications/users_with_access.html.erb
@@ -1,0 +1,54 @@
+<% content_for :title, "Users with access to #{@application.name}" %>
+
+<ol class="breadcrumb">
+  <li><%= link_to 'Applications', doorkeeper_applications_path %></li>
+  <li><%= link_to @application.name, edit_doorkeeper_application_path(@application) %></li>
+  <li class="active">Users with access</li>
+</ol>
+
+<div class="page-title">
+  <h1>Users with access to <%= @application.name %></h1>
+</div>
+
+<%= paginate @users, theme: 'twitter-bootstrap-3' %>
+
+<table class="table table-striped table-bordered">
+  <thead>
+    <tr class="table-header">
+      <th scope="col">Name and email</th>
+      <th scope="col">Role</th>
+      <th scope="col">Organisation</th>
+      <th scope="col">Sign-in count</th>
+      <th scope="col">Last sign-in</th>
+      <th scope="col">Status</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @users.each do |user| %>
+      <tr>
+        <td class="email">
+          <%= user.suspended? ? "<del>".html_safe : "" %>
+            <strong>
+              <%= link_to "#{user.name}", edit_user_path(user) %>
+            </strong>
+          <%= user.suspended? ? "</del>".html_safe : "" %>
+          <br><span class="text-muted"><%= user.email %></span>
+        </td>
+        <td class="role"><%= user.role.humanize %></td>
+        <td class="organisation"><%= user.organisation.try(:name) %></td>
+        <td><%= user.sign_in_count %></td>
+        <td class="last-sign-in">
+          <% if user.current_sign_in_at %>
+            <%= time_ago_in_words(user.current_sign_in_at) %> ago
+          <% else %>
+            never signed in
+          <% end %>
+        </td>
+        <td><%= user.status.humanize %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<%= paginate @users, theme: 'twitter-bootstrap-3' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,9 @@ Signonotron2::Application.routes.draw do
   resources :suspensions, only: [:edit, :update]
 
   resources :doorkeeper_applications, only: [:index, :edit, :update] do
+    member do
+      get :users_with_access
+    end
     resources :supported_permissions, only: [:index, :new, :create, :edit, :update]
   end
 

--- a/spec/policies/application_policy_spec.rb
+++ b/spec/policies/application_policy_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe ApplicationPolicy do
   subject { described_class }
 
-  [:index?, :edit?, :update?, :manage_supported_permissions?].each do |permission_name|
+  [:index?, :edit?, :update?, :manage_supported_permissions?, :users_with_access?].each do |permission_name|
     permissions permission_name do
       it "is allowed only for superadmins" do
         expect(subject).to permit(create(:superadmin_user), User)

--- a/test/integration/superadmin_application_users_test.rb
+++ b/test/integration/superadmin_application_users_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+
+class SuperAdminApplicationUsersTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+
+  context "logged in as an superadmin" do
+    setup do
+      @application = create(:application)
+
+      visit new_user_session_path
+      signin_with(create(:superadmin_user))
+    end
+
+    should "see all the users with access" do
+      within("ul.nav") do
+        click_link "Applications"
+      end
+
+      # Create a user that's authorized to use our app
+      @user = create(:user, name: "My Test User")
+      ::Doorkeeper::AccessToken.create!(resource_owner_id: @user.id, application_id: @application.id, token: "1234")
+
+      click_link @application.name
+
+      click_link "Users with access"
+
+      assert page.has_content?(@user.name)
+    end
+  end
+end

--- a/test/integration/superadmin_application_users_test.rb
+++ b/test/integration/superadmin_application_users_test.rb
@@ -17,14 +17,14 @@ class SuperAdminApplicationUsersTest < ActionDispatch::IntegrationTest
       end
 
       # Create a user that's authorized to use our app
-      @user = create(:user, name: "My Test User")
-      ::Doorkeeper::AccessToken.create!(resource_owner_id: @user.id, application_id: @application.id, token: "1234")
+      user = create(:user, name: "My Test User")
+      user.grant_application_permission(@application, "signin")
 
       click_link @application.name
 
       click_link "Users with access"
 
-      assert page.has_content?(@user.name)
+      assert page.has_content?(user.name)
     end
   end
 end


### PR DESCRIPTION
Team Finding Things has created a new app (Content tagger). People who have access to Panopticon should also have access to this app.

The process of providing access will be greatly helped by having a list of users that have access to panopticon. This PR adds a page for each application that lists the users that (in the past) have had access to an app.

When there are more than 100 users, pagination will be shown.

Trello: https://trello.com/c/pWDaETqu