### PR TITLE
Display 2SV set up/change device links

### DIFF
--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -10,8 +10,8 @@
     <li><%= link_to "Change your email or passphrase", edit_email_or_passphrase_user_path(current_user) %></li>
     <% if current_user.has_2sv? %>
       <li><%= link_to "Change your 2-step verification phone", two_step_verification_path, class: "js-track" %></li>
-    <% elsif current_user.require_2sv? %>
-      <li><%= link_to "Set up 2-step verification", two_step_verification_path, class: "js-track" %></li>
+    <% else %>
+      <li><%= link_to "Make your account more secure", two_step_verification_path, class: "js-track" %></li>
     <% end %>
     <li><%= link_to "Sign out", destroy_user_session_path %></li>
   </ul>

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -34,6 +34,10 @@ FactoryGirl.define do
     end
   end
 
+  factory :two_step_enabled_user, parent: :user do
+    otp_secret_key "Sssshh"
+  end
+
   factory :two_step_flagged_user, parent: :superadmin_user do
     require_2sv true
   end

--- a/test/integration/admin_user_index_test.rb
+++ b/test/integration/admin_user_index_test.rb
@@ -14,7 +14,7 @@ class AdminUserIndexTest < ActionDispatch::IntegrationTest
       org2 = create(:organisation, name: "Org 2")
 
       create(:user, name: "Aardvark", email: "aardvark@example.com", current_sign_in_at: current_time - 5.minutes)
-      create(:user, name: "Abbey", email: "abbey@example.com", otp_secret_key: 'ssshh')
+      create(:two_step_enabled_user, name: "Abbey", email: "abbey@example.com")
       create(:user, name: "Abbot", email: "mr_ab@example.com")
       create(:user, name: "Bert", email: "bbbert@example.com")
       create(:user, name: "Ed", email: "ed@example.com", organisation: org1)

--- a/test/integration/dashboard_test.rb
+++ b/test/integration/dashboard_test.rb
@@ -21,4 +21,24 @@ class DashboardTest < ActionDispatch::IntegrationTest
     assert_response_contains(app.description)
     assert page.has_css?("a[href='#{app.home_uri}']")
   end
+
+  context "when the user has enrolled in 2SV" do
+    should "display the 'change' link" do
+      user = create(:user, otp_secret_key: 'ssh')
+      visit root_path
+      signin_with(user)
+
+      assert has_link?("Change your 2-step verification phone")
+    end
+  end
+
+  context "when the user is not enrolled in 2SV" do
+    should "display the 'set up' link" do
+      user = create(:user)
+      visit root_path
+      signin_with(user)
+
+      assert has_link?("Make your account more secure")
+    end
+  end
 end

--- a/test/integration/dashboard_test.rb
+++ b/test/integration/dashboard_test.rb
@@ -24,7 +24,7 @@ class DashboardTest < ActionDispatch::IntegrationTest
 
   context "when the user has enrolled in 2SV" do
     should "display the 'change' link" do
-      user = create(:user, otp_secret_key: 'ssh')
+      user = create(:two_step_enabled_user)
       visit root_path
       signin_with(user)
 

--- a/test/integration/super_admin_reset_two_step_verification_test.rb
+++ b/test/integration/super_admin_reset_two_step_verification_test.rb
@@ -5,7 +5,7 @@ class SuperAdminResetTwoStepVerificationTest < ActionDispatch::IntegrationTest
   include ActiveJob::TestHelper
 
   setup do
-    @user = create(:user, otp_secret_key: 'sekret')
+    @user = create(:two_step_enabled_user)
   end
 
   context 'when logged in as a regular admin' do

--- a/test/models/user_export_presenter_test.rb
+++ b/test/models/user_export_presenter_test.rb
@@ -4,7 +4,7 @@ class UserExportPresenterTest < ActiveSupport::TestCase
   def setup
     Timecop.freeze(2015, 1, 15, 9, 0)
     @apps = 5.times.map {|i| create(:application, name: "App #{i}") }
-    @user = create(:user, name: 'Test User', email: 'test@dept.gov.uk', otp_secret_key: 'ssshhh')
+    @user = create(:two_step_enabled_user, name: 'Test User', email: 'test@dept.gov.uk')
     create(:supported_permission, application: @apps[0], name: 'editor')
     create(:supported_permission, application: @apps[2], name: 'editor')
     create(:supported_permission, application: @apps[2], name: 'admin')

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -94,7 +94,7 @@ class UserTest < ActiveSupport::TestCase
   context '#reset_2sv!' do
     setup do
       @super_admin   = create(:superadmin_user)
-      @two_step_user = create(:user, otp_secret_key: 'sekret')
+      @two_step_user = create(:two_step_enabled_user)
       @two_step_user.reset_2sv!(@super_admin)
     end
 
@@ -200,7 +200,7 @@ class UserTest < ActiveSupport::TestCase
 
   context ".with_2sv_enabled" do
     should "return users with 2SV enabled" do
-      enabled_user = create(:user, otp_secret_key: 'shh')
+      enabled_user = create(:two_step_enabled_user)
       enabled_users = User.with_2sv_enabled(true)
       assert_equal 1, enabled_users.count
       assert_equal enabled_user, enabled_users.first


### PR DESCRIPTION
Displays the correct links depending on the current user's 2SV enrollment.
This opens 2SV up to all users on an opt-in basis.