### PR TITLE
Scrub passphrase reset tokens from Google Analytics

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,4 +21,23 @@ module ApplicationHelper
       edit_email_or_passphrase_user_path(current_user)
     end
   end
+
+  def flash_text_without_email_addresses(message)
+    text_message = strip_tags(message)
+
+    # redact email addresses so they aren't passed to GA
+    text_message.gsub(/[\S]+@[\S]+/, '[email]')
+  end
+
+  SENSITIVE_QUERY_PARAMETERS = %w{reset_password_token invitation_token}
+
+  def sensitive_query_parameters?
+    (request.query_parameters.keys & SENSITIVE_QUERY_PARAMETERS).any?
+  end
+
+  def sanitised_fullpath
+    uri = Addressable::URI.parse(request.fullpath)
+    uri.query_values = uri.query_values.reject { |key, _value| SENSITIVE_QUERY_PARAMETERS.include?(key) }
+    uri.to_s
+  end
 end

--- a/app/helpers/bootstrap_flash_helper.rb
+++ b/app/helpers/bootstrap_flash_helper.rb
@@ -13,11 +13,4 @@ module BootstrapFlashHelper
       flash_key
     end
   end
-
-  def flash_text_without_email_addresses(message)
-    text_message = strip_tags(message)
-
-    # redact email addresses so they aren't passed to GA
-    text_message.gsub(/[\S]+@[\S]+/, '[email]')
-  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,10 @@
   <%= yield :content_for_head %>
 <% end %>
 
+<% if sensitive_query_parameters? %>
+  <% content_for :custom_pageview_fullpath, sanitised_fullpath %>
+<% end %>
+
 <% if user_signed_in? && params[:controller] !~ %r{doorkeeper/} %>
   <% unless content_for :suppress_navbar_items %>
     <% content_for :navbar_items do %>

--- a/test/units/helpers/application_helper_test.rb
+++ b/test/units/helpers/application_helper_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+
+class ApplicationHelperTest < ActionView::TestCase
+  test '#sensitive_query_parameters? returns false when no parameters in the URL' do
+    self.request = ActionDispatch::Request.new(Rack::MockRequest.env_for("/nothing-to-hide"))
+    refute sensitive_query_parameters?
+  end
+
+  test '#sensitive_query_parameters? returns false when no sensitive parameters in the URL' do
+    self.request = ActionDispatch::Request.new(Rack::MockRequest.env_for("/nothing-to-hide?share=witheveryone"))
+    refute sensitive_query_parameters?
+  end
+
+  test '#sensitive_query_parameters? returns true when there is a reset_password_token in the URL' do
+    self.request = ActionDispatch::Request.new(Rack::MockRequest.env_for("/secret-squirrel?reset_password_token=d1"))
+    assert sensitive_query_parameters?
+  end
+
+  test '#sensitive_query_parameters? returns true when there is a invitation_token in the URL' do
+    self.request = ActionDispatch::Request.new(Rack::MockRequest.env_for("/secret-squirrel?invitation_token=w1"))
+    assert sensitive_query_parameters?
+  end
+
+  test '#sanitised_fullpath returns the URL without the sensitive query parameters' do
+    self.request = ActionDispatch::Request.new(Rack::MockRequest.env_for("/secret-squirrel?invitation_token=w1&reset_password_token=d1&sharing=ok"))
+    assert_equal "/secret-squirrel?sharing=ok", sanitised_fullpath
+  end
+end


### PR DESCRIPTION
I wasn't able to find a way of testing the behaviour without changing govuk_admin_template so that it renders the Google Analytics code in test mode - currently it only renders in production mode. The unit tests of the helpers were the best I could do. One alternative would be to stub the calls to `content_for`, but this seems very unpleasant. I'm open to suggestions.