### PR TITLE
Make addressable an explicit dependency of signon

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'airbrake', '3.1.15'
 gem 'plek', '1.7.0'
 gem 'json', '1.8.3'
 gem 'whenever', '~> 0.9.4', require: false
+gem 'addressable', '~> 2.3.8'
 
 gem 'uuid'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -385,6 +385,7 @@ PLATFORMS
 
 DEPENDENCIES
   activejob-retry
+  addressable (~> 2.3.8)
   airbrake (= 3.1.15)
   alphabetical_paginate (= 2.2.3)
   ancestry (= 2.0.0)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,3 +1,5 @@
+require 'addressable/uri'
+
 module ApplicationHelper
   def nav_link(text, link)
     recognized = Rails.application.routes.recognize_path(link)


### PR DESCRIPTION
Addressable was only being loaded as a test dependency,
but being used in runtime code. This meant that the gem
was not being required in production, and uses of
`Addressable::URI` were resulting in errors.

/cc @benlovell 