### PR TITLE
Log to STDOUT and STDERR in production mode

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,6 +50,7 @@ Signonotron2::Application.configure do
 
   # Use a different logger for distributed setups.
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
+  config.logger = ActiveSupport::TaggedLogging.new(Logger.new($stderr))
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
@@ -74,9 +75,11 @@ Signonotron2::Application.configure do
 
   # Disable automatic flushing of the log to improve performance.
   # config.autoflush_log = false
+  real_stdout = $stdout.clone
+  $stdout.reopen($stderr)
 
   config.logstasher.enabled = true
-  config.logstasher.logger = Logger.new("#{Rails.root}/log/#{Rails.env}.json.log")
+  config.logstasher.logger = Logger.new(real_stdout)
   config.logstasher.suppress_app_log = true
 
   config.action_mailer.default_url_options = {


### PR DESCRIPTION
To bring this more in line with 12-facgtor principals, this changes the
logging to go to STDOUT(json), and STDERR(everything else).

Prior art:
https://github.com/alphagov/government-frontend/pull/80
https://github.com/alphagov/publishing-api/pull/109

Related puppet change: https://github.com/alphagov/govuk-puppet/pull/4023