### PR TITLE
Extract department specific text to locale file

### DIFF
--- a/app/controllers/devise/two_step_verification_controller.rb
+++ b/app/controllers/devise/two_step_verification_controller.rb
@@ -27,7 +27,7 @@ class Devise::TwoStepVerificationController < DeviseController
   end
 
   def otp_secret_key_uri
-    issuer = "GOV.UK%20Signon"
+    issuer = I18n.t('devise.issuer')
     if Rails.application.config.instance_name
       issuer = "#{Rails.application.config.instance_name.titleize}%20#{issuer}"
     end

--- a/app/mailers/mailer_helper.rb
+++ b/app/mailers/mailer_helper.rb
@@ -4,18 +4,14 @@ module MailerHelper
   end
 
   def app_name
-    if instance_name.present?
-      "GOV.UK Signon #{instance_name}"
-    else
-      "GOV.UK Signon"
-    end
+    I18n.t('mailer.app_name', instance_name: instance_name)
   end
 
   def email_from_address
     if instance_name.present?
-      "noreply-signon-#{instance_name.parameterize}@digital.cabinet-office.gov.uk"
+      I18n.t('mailer.email_from_address.instance', instance_name: instance_name.parameterize)
     else
-      "noreply-signon@digital.cabinet-office.gov.uk"
+      I18n.t('mailer.email_from_address.no-instance')
     end
   end
 

--- a/app/mailers/noisy_batch_invitation.rb
+++ b/app/mailers/noisy_batch_invitation.rb
@@ -2,7 +2,7 @@ class NoisyBatchInvitation < ActionMailer::Base
   include MailerHelper
 
   default from: Proc.new { email_from }
-  default to: "signon-alerts@digital.cabinet-office.gov.uk"
+  default to: I18n.t('noisy_batch_invitation_mailer.to')
 
   def make_noise(batch_invitation)
     @user = batch_invitation.user

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -1,6 +1,6 @@
 <p>Hello <%= @resource.name %>,</p>
 
-<p>Someone has invited you to GOV.UK Signon, you can accept it through the link below.</p>
+<p>Someone has invited you to <%= t('department_name') %> Signon, you can accept it through the link below.</p>
 
 <p><%= link_to 'Accept invitation', accept_invitation_url(@resource, :invitation_token => @token) %></p>
 

--- a/app/views/devise/mailer/invitation_instructions.text.erb
+++ b/app/views/devise/mailer/invitation_instructions.text.erb
@@ -1,6 +1,6 @@
 Hello <%= @resource.name %>,
 
-Someone has invited you to GOV.UK Signon, you can accept it copying-and-pasting the link below into your browser's URL bar:
+Someone has invited you to <%= t('department_name') %> Signon, you can accept it copying-and-pasting the link below into your browser's URL bar:
 
 <%= accept_invitation_url(@resource, :invitation_token => @token) %>
 

--- a/app/views/devise/two_step_verification_session/max_2sv_login_attempts_reached.html.erb
+++ b/app/views/devise/two_step_verification_session/max_2sv_login_attempts_reached.html.erb
@@ -10,9 +10,5 @@
     Your account has been locked because an incorrect 2-step verification code was entered too many times.
   </p>
   <p>Your account will be unlocked at <%= Devise.unlock_in.from_now.to_s(:govuk_time)%></p>
-  <p>
-    If you need your account unlocked sooner, please contact a managing GOV.UK editor in your organisation
-    (or your parent organisation). They can either unlock your account themselves or use the support form
-    to get help from the GOV.UK team.
-  </p>
+  <p><%= t('devise.two_step_verification_session.max_2sv_login_attempts_reached.quick_unlock_message') %></p>
 </div>

--- a/app/views/devise/two_step_verification_session/new.html.erb
+++ b/app/views/devise/two_step_verification_session/new.html.erb
@@ -26,10 +26,12 @@
       <div data-module="toggle">
         <%= link_to "Can’t get your verification code?", "#", class: "js-toggle js-toggle-target if-no-js-hide js-track" %>
         <div class="js-toggle-target if-js-hide">
-          <h4>Contact GOV.UK</h4>
-          <p>If you can’t get your verification code, you’ll need to ask <%= link_to "GOV.UK", "https://www.gov.uk/" %> to reset 2-step verification on your Signon account.</p>
-          <p>If you can’t do this yourself, you’ll need to contact a managing <%= link_to "GOV.UK", "https://www.gov.uk/" %> editor in your organisation (or your parent organisation). They can raise a <%= link_to "support ticket", "https://www.gov.uk/support/internal/" %> on your behalf.</p>
-          <p><%= link_to "GOV.UK", "https://www.gov.uk/" %> is only able to respond to these requests 9am to 5pm, Monday to Friday.</p>
+          <h4><%= t('.contact_header') %></h4>
+          <%= t('.contact_details',
+            department_link: link_to(t('department_name'), t('department_url')),
+            support_ticket_link: link_to('support ticket', "#{t('department_url')}support/internal/")).each do |_, paragraph| %>
+            <p><%= paragraph %></p>
+          <% end %>
         </div>
       </div>
     </div>

--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -1,0 +1,17 @@
+# this is required to catch errors thrown from calls to I18n directly - primarily mailers
+
+if Rails.env.test?
+  module I18n
+    class AlwaysRaiseExceptionHandler < ExceptionHandler
+      def call(exception, locale, key, options)
+        if exception.is_a?(MissingTranslation)
+          raise exception.to_exception
+        else
+          super
+        end
+      end
+    end
+  end
+
+  I18n.exception_handler = I18n::AlwaysRaiseExceptionHandler.new
+end

--- a/config/locales/department_specific.en.yml
+++ b/config/locales/department_specific.en.yml
@@ -1,0 +1,3 @@
+en:
+  devise:
+    issuer: "GOV.UK%20Signon"

--- a/config/locales/department_specific.en.yml
+++ b/config/locales/department_specific.en.yml
@@ -1,6 +1,25 @@
 en:
+  department_name: "GOV.UK"
+  department_url: "https://www.gov.uk/"
   devise:
     issuer: "GOV.UK%20Signon"
+    two_step_verification_session:
+      max_2sv_login_attempts_reached:
+        quick_unlock_message: |
+          If you need your account unlocked sooner, please contact a managing GOV.UK editor in your organisation
+          (or your parent organisation). They can either unlock your account themselves or use the support form
+          to get help from the GOV.UK team.
+      new:
+        contact_header: Contact GOV.UK
+        contact_details:
+          para1: |
+            If you can’t get your verification code, you’ll need to ask %{department_link} to reset 2-step
+            verification on your Signon account.
+          para2: |
+            If you can’t do this yourself, you’ll need to contact a managing %{department_link} editor in your
+            organisation (or your parent organisation). They can raise a %{support_ticket_link} on your behalf.
+          para3: |
+            %{department_link} is only able to respond to these requests 9am to 5pm, Monday to Friday.
   mailer:
     app_name: "GOV.UK Signon %{instance_name}"
     email_from_address:

--- a/config/locales/department_specific.en.yml
+++ b/config/locales/department_specific.en.yml
@@ -1,3 +1,12 @@
 en:
   devise:
     issuer: "GOV.UK%20Signon"
+  mailer:
+    app_name: "GOV.UK Signon %{instance_name}"
+    email_from_address:
+      instance: "noreply-signon-%{instance_name}@digital.cabinet-office.gov.uk"
+      no-instance: "noreply-signon@digital.cabinet-office.gov.uk"
+
+  noisy_batch_invitation_mailer:
+    to: "signon-alerts@digital.cabinet-office.gov.uk"
+

--- a/test/controllers/two_step_verification_controller_test.rb
+++ b/test/controllers/two_step_verification_controller_test.rb
@@ -50,6 +50,13 @@ class TwoStepVerificationControllerTest < ActionController::TestCase
       end
     end
 
+    context "when different issuer name is provided within the localisation data" do
+      should "use the value provided by i18n" do
+        I18n.stubs(t: 'issuer%20test')
+        assert_match %r{issuer=Development%20issuer%20test}, @controller.otp_secret_key_uri
+      end
+    end
+
     should "include the user's email" do
       assert_match %r{#{@user.email}}, @controller.otp_secret_key_uri
     end

--- a/test/models/noisy_batch_invitation_test.rb
+++ b/test/models/noisy_batch_invitation_test.rb
@@ -47,4 +47,19 @@ class NoisyBatchInvitationTest < ActionMailer::TestCase
       assert_equal '"GOV.UK Signon Test Fools" <noreply-signon-test-fools@digital.cabinet-office.gov.uk>', @email[:from].to_s
     end
   end
+
+  context "work correctly when no instance name is set" do
+    setup do
+      Rails.application.config.stubs(:instance_name).returns(nil)
+
+      user = create(:user, name: "Bob Loblaw")
+      @batch_invitation = create(:batch_invitation, user: user)
+      create(:batch_invitation_user, batch_invitation: @batch_invitation)
+      @email = NoisyBatchInvitation.make_noise(@batch_invitation).deliver_now
+    end
+
+    should "from address should include the instance name" do
+      assert_equal '"GOV.UK Signon" <noreply-signon@digital.cabinet-office.gov.uk>', @email[:from].to_s
+    end
+  end
 end


### PR DESCRIPTION
**NOTE:** This pull request is an example only and not fully implemented.

This is a proposed solution that would allow the PensionWise team to use the Signonotron code with different text at key points within the application without requiring multiple files to be changed within a branch.

This would make merging changes from the main application easy as only the locale file would be significantly different.