### PR TITLE
Broken translation

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -36,7 +36,7 @@ Signonotron2::Application.configure do
   config.active_support.deprecation = :stderr
 
   # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  config.action_view.raise_on_missing_translations = true
 
   config.active_support.test_order = :random
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,8 +18,9 @@ en:
 
   users:
     edit:
-      change_passphrase: "Change your passphrase"
       change: "Change passphrase"
+    edit_email_or_passphrase:
+      change_passphrase: "Change your passphrase"
 
   supported_permissions:
     form:


### PR DESCRIPTION
Found this missing translation.

Have a separate commit for enabling errors when running tests so that it can be excluded depending on preference.