### PR TITLE
Fix app_title display translation missing

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,3 +1,4 @@
+<% content_for :app_title, "#{t('department.name')} Signon" %>
 <% content_for :page_title, "#{yield(:title)} | #{t('department.name')} Signon" %>
 <% content_for :head do %>
   <%= csrf_meta_tags %>

--- a/config/initializers/govuk_admin_template.rb
+++ b/config/initializers/govuk_admin_template.rb
@@ -1,3 +1,3 @@
-GovukAdminTemplate.configure do |c|
-  c.app_title = "#{I18n.t('department.name')} Signon"
-end
+# We were setting app_title here, but we needed to use the department.name from
+# localisations, which aren't available in initializers. Our solution was to move
+# it to app/views/application.html.erb.


### PR DESCRIPTION
Since c79a5143d7dfcd8dd02e3913980cef879e269b2a, we were using Rails' I18n to
set the GovukAdminTemplate.app_title in an initializer. Unfortunately, whilst
the I18n code is available, it hasn't been configured at the time intializers
are loaded. This meant that users saw this in the page header:
```
  translation missing: en.department.name Signon
```
The tests didn't fail because the setting to make missing translations raise
errors (in config/environments/test.rb) is also loaded after initializers.