### PR TITLE
Fix emails not being sent

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -7,7 +7,7 @@ Devise.setup do |config|
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class with default "from" parameter.
-  config.mailer_sender = Class.new.extend(MailerHelper).email_from
+  # config.mailer_sender = Class.new.extend(MailerHelper).email_from
 
   # Configure the class responsible to send e-mails.
   config.mailer = "UserMailer"

--- a/test/integration/batch_inviting_users_test.rb
+++ b/test/integration/batch_inviting_users_test.rb
@@ -22,6 +22,9 @@ class BatchInvitingUsersTest < ActionDispatch::IntegrationTest
       invited_user = User.find_by_email("fred@example.com")
       assert_not_nil invited_user
       assert invited_user.has_access_to?(application)
+      assert_equal "noreply-signon-development@digital.cabinet-office.gov.uk", last_email.from[0]
+      assert_equal nil, last_email.reply_to[0]
+
       assert_equal "fred@example.com", last_email.to[0]
       assert_match 'Please confirm your account', last_email.subject
     end

--- a/test/integration/passphrase_reset_test.rb
+++ b/test/integration/passphrase_reset_test.rb
@@ -45,6 +45,8 @@ class PassphraseResetTest < ActionDispatch::IntegrationTest
 
       open_email(user.email)
       assert current_email
+      assert_equal "noreply-signon-development@digital.cabinet-office.gov.uk", current_email.from[0]
+      assert_equal nil, last_email.reply_to[0]
       assert_equal "Reset passphrase instructions", current_email.subject
 
       # partially signed-in user should be able to reset passphrase using link in reset passphrase instructions


### PR DESCRIPTION
Since ec36b330c44eecc9b345dccdd6daaf25f0a585bc, we have used I18n to get the
email_from value. Because initializers are loaded before I18n has been
configured with a load path, when the Devise.config.mailer_sender was set, it
received an I18n translation missing message, instead of the email address
string. This was then apparently used by Devise to set the Reply To field and
probably the From field.

When UserMailer and NoisyBatchInvitation mailer call I18n, it has had a load
path set and so override the From field with correct/valid values, but the
Reply To field isn't.

The result was that emails were probably being rejected either by our email
sending service (Amazon SES) or elsewhere, so emails weren't being sent to
users.

Reading the comment for Devise.config.mailer_sender, it isn't neccessary to set
it if you set a custom Devise.config.mailer, so I tried removing this call and
the reply_to was no longer set at all.

@dwhenry you might be affected by this bug.