### PR TITLE
Record when a passphrase reset page is visited with expired token

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -7,6 +7,7 @@ class PasswordsController < Devise::PasswordsController
 
     user = user_from_params
     unless user && user.reset_password_period_valid?
+      record_reset_page_loaded_token_expired
       render 'devise/passwords/reset_error'
     end
   end
@@ -45,6 +46,10 @@ private
 
   def record_reset_page_loaded
     EventLog.record_event(user_from_params, EventLog::PASSPHRASE_RESET_LOADED) if user_from_params
+  end
+
+  def record_reset_page_loaded_token_expired
+    EventLog.record_event(user_from_params, EventLog::PASSPHRASE_RESET_LOADED_BUT_TOKEN_EXPIRED) if user_from_params
   end
 
   def record_password_reset_failure(user)

--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -34,6 +34,7 @@ class EventLog < ActiveRecord::Base
     ACCESS_TOKEN_REGENERATED              = LogEntry.new(id: 28, description: "Access token re-generated", require_application: true),
     ACCESS_TOKEN_GENERATED                = LogEntry.new(id: 29, description: "Access token generated", require_application: true, require_initiator: true),
     ACCESS_TOKEN_REVOKED                  = LogEntry.new(id: 30, description: "Access token revoked", require_application: true, require_initiator: true),
+    PASSPHRASE_RESET_LOADED_BUT_TOKEN_EXPIRED = LogEntry.new(id: 31, description: "Passphrase reset page loaded but the token has expired"),
   ]
 
   EVENTS_REQUIRING_INITIATOR   = EVENTS.select(&:require_initiator?)

--- a/test/integration/event_log_test.rb
+++ b/test/integration/event_log_test.rb
@@ -58,6 +58,15 @@ class EventLogIntegrationTest < ActionDispatch::IntegrationTest
     assert_equal EventLog::PASSPHRASE_RESET_LOADED, @user.event_logs.first.entry
   end
 
+  test "record passphrase reset page loaded but token expired" do
+    token_received_in_email = Timecop.freeze((User.reset_password_within + 1.hour).ago) do
+      @user.send_reset_password_instructions
+    end
+    visit edit_user_password_path(reset_password_token: token_received_in_email)
+
+    assert_equal EventLog::PASSPHRASE_RESET_LOADED_BUT_TOKEN_EXPIRED, @user.event_logs.first.entry
+  end
+
   test "record passphrase reset failed" do
     token_received_in_email = @user.send_reset_password_instructions
     visit edit_user_password_path(reset_password_token: token_received_in_email)


### PR DESCRIPTION
It would be useful to see when users are trying to use expired tokens.

Note that we can't log when a user tries to use a token from a passphrase reset
request that has been followed by another passphrase reset request. This is
because we can't relate the token to a user, because it is overwritten.