### PR TITLE
Make tests agnostic of department name, email, etc.

### DIFF
--- a/test/controllers/batch_invitations_controller_test.rb
+++ b/test/controllers/batch_invitations_controller_test.rb
@@ -74,7 +74,7 @@ class BatchInvitationsControllerTest < ActionController::TestCase
         post :create, batch_invitation: { user_names_and_emails: users_csv }, user: { supported_permission_ids: [] }
 
         email = ActionMailer::Base.deliveries.detect do |m|
-          m.to == ["signon-alerts@digital.cabinet-office.gov.uk"]
+          m.to.any? { |to| to =~ /signon-alerts@.*\.gov\.uk/ }
         end
         assert_not_nil email
         assert_equal "[SIGNON] #{@user.name} created a batch of 2 users in development", email.subject

--- a/test/controllers/two_step_verification_controller_test.rb
+++ b/test/controllers/two_step_verification_controller_test.rb
@@ -32,7 +32,7 @@ class TwoStepVerificationControllerTest < ActionController::TestCase
     end
 
     should "include the environment titleised" do
-      assert_match %r{issuer=Development%20GOV.UK%20Signon}, @controller.otp_secret_key_uri
+      assert_match %r{issuer=Development%20.*%20Signon}, @controller.otp_secret_key_uri
     end
 
     context "in production" do
@@ -46,7 +46,8 @@ class TwoStepVerificationControllerTest < ActionController::TestCase
       end
 
       should "not include the environment name" do
-        assert_match %r{issuer=GOV.UK%20Signon}, @controller.otp_secret_key_uri
+        assert_match %r{issuer=.*%20Signon}, @controller.otp_secret_key_uri
+        refute_match %r{issuer=Development%20.*%20Signon}, @controller.otp_secret_key_uri
       end
     end
 

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -86,7 +86,7 @@ class UsersControllerTest < ActionController::TestCase
           assert_equal "new@email.com", confirmation_email.to.first
 
           email_changed_notification = ActionMailer::Base.deliveries.last
-          assert_equal "Your GOV.UK Signon development email address is being changed", email_changed_notification.subject
+          assert_match /Your .* Signon development email address is being changed/, email_changed_notification.subject
           assert_equal "old@email.com", email_changed_notification.to.first
         end
       end
@@ -571,7 +571,8 @@ class UsersControllerTest < ActionController::TestCase
             put :update, id: normal_user.id, user: { email: "new@email.com" }
 
             email_change_notifications = ActionMailer::Base.deliveries[-2..-1]
-            assert_equal ['Your GOV.UK Signon development email address has been updated'], email_change_notifications.map(&:subject).uniq
+            assert_equal email_change_notifications.map(&:subject).uniq.count, 1
+            assert_match /Your .* Signon development email address has been updated/, email_change_notifications.map(&:subject).first
             assert_equal %w(old@email.com new@email.com), email_change_notifications.map {|mail| mail.to.first }
           end
         end

--- a/test/integration/email_change_test.rb
+++ b/test/integration/email_change_test.rb
@@ -20,7 +20,7 @@ class EmailChangeTest < ActionDispatch::IntegrationTest
           admin_changes_email_address(user: user, new_email: "new@email.com")
 
           assert_equal "new@email.com", last_email.to[0]
-          assert_equal 'Your GOV.UK Signon development email address has been updated', last_email.subject
+          assert_match /Your .* Signon development email address has been updated/, last_email.subject
         end
       end
 
@@ -110,7 +110,7 @@ class EmailChangeTest < ActionDispatch::IntegrationTest
         assert_equal "new@email.com", confirmation_email.to.first
         assert_equal 'Confirm your email change', confirmation_email.subject
         assert_equal "original@email.com", notification_email.to.first
-        assert_equal 'Your GOV.UK Signon development email address is being changed', notification_email.subject
+        assert_match /Your .* Signon development email address is being changed/, notification_email.subject
       end
     end
 

--- a/test/integration/sign_in_test.rb
+++ b/test/integration/sign_in_test.rb
@@ -79,13 +79,13 @@ class SignInTest < ActionDispatch::IntegrationTest
     should "not prompt for a verification code twice per browser in 30 days" do
       visit root_path
       signin_with(email: "email@example.com", password: "some passphrase with various $ymb0l$")
-      assert_response_contains "Welcome to GOV.UK"
+      assert_response_contains "Welcome to"
 
       signout
       visit root_path
 
       signin_with(email: "email@example.com", password: "some passphrase with various $ymb0l$", second_step: false)
-      assert_response_contains "Welcome to GOV.UK"
+      assert_response_contains "Welcome to"
 
       signout
       visit root_path
@@ -93,7 +93,7 @@ class SignInTest < ActionDispatch::IntegrationTest
       Timecop.travel(30.days.from_now + 1) do
         visit root_path
         signin_with(email: "email@example.com", password: "some passphrase with various $ymb0l$")
-        assert_response_contains "Welcome to GOV.UK"
+        assert_response_contains "Welcome to"
       end
     end
 
@@ -108,7 +108,7 @@ class SignInTest < ActionDispatch::IntegrationTest
     should "allow access with a correctly-generated code" do
       visit root_path
       signin_with(email: "email@example.com", password: "some passphrase with various $ymb0l$")
-      assert_response_contains "Welcome to GOV.UK"
+      assert_response_contains "Welcome to"
       assert_response_contains "Signed in successfully"
       assert_equal 1, EventLog.where(event_id: EventLog::TWO_STEP_VERIFIED.id, uid: @user.uid).count
     end
@@ -193,7 +193,7 @@ class SignInTest < ActionDispatch::IntegrationTest
     should "not remember a user's 2SV session if they've changed 2SV secret" do
       visit root_path
       signin_with(email: "email@example.com", password: "some passphrase with various $ymb0l$")
-      assert_response_contains "Welcome to GOV.UK"
+      assert_response_contains "Welcome to"
 
       signout
       visit root_path
@@ -208,7 +208,7 @@ class SignInTest < ActionDispatch::IntegrationTest
     should "not prevent login if 2SV is disabled for user with a remembered session" do
       visit root_path
       signin_with(email: "email@example.com", password: "some passphrase with various $ymb0l$")
-      assert_response_contains "Welcome to GOV.UK"
+      assert_response_contains "Welcome to"
 
       signout
       visit root_path

--- a/test/integration/user_locking_test.rb
+++ b/test/integration/user_locking_test.rb
@@ -12,7 +12,7 @@ class UserLockingTest < ActionDispatch::IntegrationTest
       signin_with(user)
 
       assert_equal user.email, last_email.to[0]
-      assert_equal "Your GOV.UK Signon development account has been locked", last_email.subject
+      assert_match /Your .* Signon development account has been locked/, last_email.subject
 
       assert_response_contains("Invalid email or passphrase.")
 

--- a/test/models/noisy_batch_invitation_test.rb
+++ b/test/models/noisy_batch_invitation_test.rb
@@ -10,11 +10,12 @@ class NoisyBatchInvitationTest < ActionMailer::TestCase
     end
 
     should "come from noreply-signon@" do
-      assert_equal '"GOV.UK Signon development" <noreply-signon-development@digital.cabinet-office.gov.uk>', @email[:from].to_s
+      assert_match /".* Signon development" <noreply-signon-development@.*\.gov\.uk>/, @email[:from].to_s
     end
 
     should "send to noreply-signon@" do
-      assert_equal ["signon-alerts@digital.cabinet-office.gov.uk"], @email.to
+      assert_equal @email.to.count, 1
+      assert_match /signon-alerts@.*\.gov\.uk/, @email.to.first
     end
 
     should "have a subject" do
@@ -44,7 +45,7 @@ class NoisyBatchInvitationTest < ActionMailer::TestCase
     end
 
     should "from address should include the instance name" do
-      assert_equal '"GOV.UK Signon Test Fools" <noreply-signon-test-fools@digital.cabinet-office.gov.uk>', @email[:from].to_s
+      assert_match /".* Signon Test Fools" <noreply-signon-test-fools@.*\.gov\.uk>/, @email[:from].to_s
     end
   end
 
@@ -59,7 +60,7 @@ class NoisyBatchInvitationTest < ActionMailer::TestCase
     end
 
     should "from address should include the instance name" do
-      assert_equal '"GOV.UK Signon" <noreply-signon@digital.cabinet-office.gov.uk>', @email[:from].to_s
+      assert_match /".* Signon" <noreply-signon@.*\.gov\.uk>/, @email[:from].to_s
     end
   end
 end

--- a/test/models/user_mailer_test.rb
+++ b/test/models/user_mailer_test.rb
@@ -63,7 +63,7 @@ class UserMailerTest < ActionMailer::TestCase
     end
 
     should "include an instance name in the subject" do
-      assert_includes @email.subject, "Your GOV.UK Signon development account"
+      assert_match /Your .* Signon development account/, @email.subject
     end
 
     should "include an instance name in the body" do
@@ -94,7 +94,7 @@ class UserMailerTest < ActionMailer::TestCase
     end
 
     should "include the instance name in the subject" do
-      assert_includes @email.subject, "Your GOV.UK Signon test account"
+      assert_match /Your .* Signon test account/, @email.subject
     end
 
     should "include the instance name in the body" do


### PR DESCRIPTION
Remove department specific names from test suit to allow test to pass when an alternative department name is used.