### PR TITLE
Ignore dictionary file when searching via `ag`

### DIFF
--- a/.agignore
+++ b/.agignore
@@ -1,0 +1,1 @@
+vendor/assets/javascripts/zxcvbn.js


### PR DESCRIPTION
Anytime I search this project the dictionary file comes up with hits
and this is annoying and wasteful.