### PR TITLE
Bump admin gem to 4.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'bootstrap-kaminari-views', '0.0.5'
 gem 'alphabetical_paginate', '2.2.3'
 gem 'mysql2', '0.3.20'
 gem 'pg', '~> 0.18'
-gem 'govuk_admin_template', '4.1.1'
+gem 'govuk_admin_template', '4.2.0'
 gem 'deprecated_columns', '0.1.0'
 
 gem 'rails-html-sanitizer', '1.0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,9 +51,8 @@ GEM
     ast (2.1.0)
     astrolabe (1.3.1)
       parser (~> 2.2)
-    autoprefixer-rails (6.3.1)
+    autoprefixer-rails (6.3.5)
       execjs
-      json
     bcrypt (3.1.10)
     better_errors (2.1.1)
       coderay (>= 1.0.0)
@@ -174,7 +173,7 @@ GEM
       activesupport (>= 4.1.0)
     govuk-lint (0.4.1)
       rubocop (~> 0.32)
-    govuk_admin_template (4.1.1)
+    govuk_admin_template (4.2.0)
       bootstrap-sass (= 3.3.5.1)
       jquery-rails (~> 3.1.3)
       rails (>= 3.2.0)
@@ -406,7 +405,7 @@ DEPENDENCIES
   factory_girl_rails (~> 4.5.0)
   gds-api-adapters (= 20.1.1)
   govuk-lint (~> 0.4)
-  govuk_admin_template (= 4.1.1)
+  govuk_admin_template (= 4.2.0)
   jasmine (= 2.1.0)
   json (= 1.8.3)
   kaminari (~> 0.16.3)

--- a/app/helpers/analytics_helper.rb
+++ b/app/helpers/analytics_helper.rb
@@ -3,7 +3,7 @@ module AnalyticsHelper
     {
       'module' => 'auto-track-event',
       'track-action' => "alert-#{type}",
-      'track-label' => flash_text_without_email_addresses(message)
+      'track-label' => strip_tags(message)
     }
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,13 +24,6 @@ module ApplicationHelper
     end
   end
 
-  def flash_text_without_email_addresses(message)
-    text_message = strip_tags(message)
-
-    # redact email addresses so they aren't passed to GA
-    text_message.gsub(/[\S]+@[\S]+/, '[email]')
-  end
-
   SENSITIVE_QUERY_PARAMETERS = %w{reset_password_token invitation_token}
 
   def sensitive_query_parameters?


### PR DESCRIPTION
* Pick up change to automatically strip email addresses from all event actions and labels: https://github.com/alphagov/govuk_admin_template/pull/121
* Remove now redundant email substitution.

https://trello.com/c/0SLWcJwI/337-strip-personally-identifiable-information-before-sending-to-analytics-medium