### PR TITLE
Update text: managing editors can use support form

### DIFF
--- a/app/views/user_mailer/suspension_notification.html.erb
+++ b/app/views/user_mailer/suspension_notification.html.erb
@@ -8,6 +8,6 @@
 
 <p>If you don't need the account you can ignore this email.</p>
 
-<p>If you do still need the account you will have to contact a managing <%= link_to t('department.name'), t('department.url') %> editor in your organisation (or your parent organisation). They can either unsuspend your account themselves or use the support form to get help from the <%= link_to t('department.name'), t('department.url') %> team.</p>
+<p>If you do still need the account you will have to contact a managing <%= link_to t('department.name'), t('department.url') %> editor in your organisation (or your parent organisation). They can either use the support form to get help from the <%= link_to t('department.name'), t('department.url') %> team.</p>
 
 <p>Read our blog post about <%= link_to "suspending unused #{t('department.name')} accounts", 'https://insidegovuk.blog.gov.uk/2014/08/21/suspending-unused-gov-uk-accounts' %>.</p>


### PR DESCRIPTION
Email was stating that managing editors can un-suspend accounts. Managing editors don't have this permission.

Updated to say that they can use the support form only.