### PR TITLE
Update text: managing editors can use support form

### DIFF
--- a/app/views/user_mailer/unlock_instructions.html.erb
+++ b/app/views/user_mailer/unlock_instructions.html.erb
@@ -4,4 +4,4 @@
 <p><%= account_name.humanize %> locks do not lock production accounts.</p>
 <% end %>
 
-<p>Your account will be unlocked at <%= unlock_time %>. If you need your account unlocked sooner, please contact a managing <%= link_to t('department.name'), t('department.url') %> editor in your organisation (or your parent organisation). They can either unlock your account themselves or use the support form to get help from the <%= link_to t('department.name'), t('department.url') %> team.</p>
+<p>Your account will be unlocked at <%= unlock_time %>. If you need your account unlocked sooner, please contact a managing <%= link_to t('department.name'), t('department.url') %> editor in your organisation (or your parent organisation). They can use the support form to get help from the <%= link_to t('department.name'), t('department.url') %> team.</p>


### PR DESCRIPTION
Email was stating that managing editors can un-suspend accounts. Managing editors don't have this permission.

Updated to say that they can use the support form only.