### PR TITLE
Update text: managing editors can use support form

### DIFF
--- a/app/views/user_mailer/suspension_notification.text.erb
+++ b/app/views/user_mailer/suspension_notification.text.erb
@@ -8,7 +8,7 @@ Your <%= t('department.name') %> Signon <%= account_name %>, for <%= @user.email
 
 If you don't need the account you can ignore this email.
 
-If you do still need the account you will have to contact a managing <%= t('department.name') %> editor in your organisation (or your parent organisation). They can either unsuspend your account themselves or use the support form to get help from the <%= t('department.name') %> team.
+If you do still need the account you will have to contact a managing <%= t('department.name') %> editor in your organisation (or your parent organisation). They can either use the support form to get help from the <%= t('department.name') %> team.
 
 Read our blog post about suspending unused <%= t('department.name') %> accounts:
 


### PR DESCRIPTION
Email was stating that managing editors can un-suspend accounts. Managing editors don't have this permission.

Updated to say that they can use the support form only.