### PR TITLE
Update text: managing editors can use support form

### DIFF
--- a/app/views/user_mailer/notify_reset_password_disallowed_due_to_suspension.text.erb
+++ b/app/views/user_mailer/notify_reset_password_disallowed_due_to_suspension.text.erb
@@ -5,4 +5,4 @@ Your <%= t('department.name') %> Signon <%= account_name %>, for <%= @user.email
 <%= account_name.humanize %> suspensions do not suspend production accounts.
 <% end %>
 
-If you believe your account has been suspended in error, please contact a managing <%= t('department.name') %> editor in your organisation (or your parent organisation). They can either unsuspend your account themselves or use the support form to get help from the <%= t('department.name') %> team.
+If you believe your account has been suspended in error, please contact a managing <%= t('department.name') %> editor in your organisation (or your parent organisation). They can use the support form to get help from the <%= t('department.name') %> team.


### PR DESCRIPTION
Email was stating that managing editors can un-suspend accounts. Managing editors don't have this permission.

Updated to say that they can use the support form only.