### PR TITLE
Update text: managing editors can use support form

### DIFF
--- a/app/views/user_mailer/notify_reset_password_disallowed_due_to_suspension.html.erb
+++ b/app/views/user_mailer/notify_reset_password_disallowed_due_to_suspension.html.erb
@@ -4,4 +4,4 @@
 <p><%= account_name.humanize %> suspensions do not suspend production accounts.</p>
 <% end %>
 
-<p>If you believe your account has been suspended in error, please contact a managing <%= link_to t('department.name'), t('department.url') %> editor in your organisation (or your parent organisation). They can either unsuspend your account themselves or use the support form to get help from the <%= link_to t('department.name'), t('department.url') %> team.</p>
+<p>If you believe your account has been suspended in error, please contact a managing <%= link_to t('department.name'), t('department.url') %> editor in your organisation (or your parent organisation). They can use the support form to get help from the <%= link_to t('department.name'), t('department.url') %> team.</p>


### PR DESCRIPTION
Email was stating that managing editors can un-suspend accounts. Managing editors don't have this permission.

Updated to say that they can use the support form only.