### PR TITLE
Update managing editors copy in emails

### DIFF
--- a/app/views/devise/two_step_verification_session/max_2sv_login_attempts_reached.html.erb
+++ b/app/views/devise/two_step_verification_session/max_2sv_login_attempts_reached.html.erb
@@ -12,7 +12,6 @@
   <p>Your account will be unlocked at <%= Devise.unlock_in.from_now.to_s(:govuk_time)%></p>
   <p>
     If you need your account unlocked sooner, please contact a managing <%= t('department.name') %> editor in your organisation
-    (or your parent organisation). They can either unlock your account themselves or use the support form
-    to get help from the <%= t('department.name') %> team.
+    (or your parent organisation). They can use the support form to get help from the <%= t('department.name') %> team.
   </p>
 </div>

--- a/app/views/user_mailer/notify_reset_password_disallowed_due_to_suspension.html.erb
+++ b/app/views/user_mailer/notify_reset_password_disallowed_due_to_suspension.html.erb
@@ -4,4 +4,4 @@
 <p><%= account_name.humanize %> suspensions do not suspend production accounts.</p>
 <% end %>
 
-<p>If you believe your account has been suspended in error, please contact a managing <%= link_to t('department.name'), t('department.url') %> editor in your organisation (or your parent organisation). They can either unsuspend your account themselves or use the support form to get help from the <%= link_to t('department.name'), t('department.url') %> team.</p>
+<p>If you believe your account has been suspended in error, please contact a managing <%= link_to t('department.name'), t('department.url') %> editor in your organisation (or your parent organisation). They can use the support form to get help from the <%= link_to t('department.name'), t('department.url') %> team.</p>

--- a/app/views/user_mailer/notify_reset_password_disallowed_due_to_suspension.text.erb
+++ b/app/views/user_mailer/notify_reset_password_disallowed_due_to_suspension.text.erb
@@ -5,4 +5,4 @@ Your <%= t('department.name') %> Signon <%= account_name %>, for <%= @user.email
 <%= account_name.humanize %> suspensions do not suspend production accounts.
 <% end %>
 
-If you believe your account has been suspended in error, please contact a managing <%= t('department.name') %> editor in your organisation (or your parent organisation). They can either unsuspend your account themselves or use the support form to get help from the <%= t('department.name') %> team.
+If you believe your account has been suspended in error, please contact a managing <%= t('department.name') %> editor in your organisation (or your parent organisation). They can use the support form to get help from the <%= t('department.name') %> team.

--- a/app/views/user_mailer/suspension_notification.html.erb
+++ b/app/views/user_mailer/suspension_notification.html.erb
@@ -8,6 +8,6 @@
 
 <p>If you don't need the account you can ignore this email.</p>
 
-<p>If you do still need the account you will have to contact a managing <%= link_to t('department.name'), t('department.url') %> editor in your organisation (or your parent organisation). They can either unsuspend your account themselves or use the support form to get help from the <%= link_to t('department.name'), t('department.url') %> team.</p>
+<p>If you do still need the account you will have to contact a managing <%= link_to t('department.name'), t('department.url') %> editor in your organisation (or your parent organisation). They can use the support form to get help from the <%= link_to t('department.name'), t('department.url') %> team.</p>
 
 <p>Read our blog post about <%= link_to "suspending unused #{t('department.name')} accounts", 'https://insidegovuk.blog.gov.uk/2014/08/21/suspending-unused-gov-uk-accounts' %>.</p>

--- a/app/views/user_mailer/suspension_notification.text.erb
+++ b/app/views/user_mailer/suspension_notification.text.erb
@@ -8,7 +8,7 @@ Your <%= t('department.name') %> Signon <%= account_name %>, for <%= @user.email
 
 If you don't need the account you can ignore this email.
 
-If you do still need the account you will have to contact a managing <%= t('department.name') %> editor in your organisation (or your parent organisation). They can either unsuspend your account themselves or use the support form to get help from the <%= t('department.name') %> team.
+If you do still need the account you will have to contact a managing <%= t('department.name') %> editor in your organisation (or your parent organisation). They can use the support form to get help from the <%= t('department.name') %> team.
 
 Read our blog post about suspending unused <%= t('department.name') %> accounts:
 

--- a/app/views/user_mailer/unlock_instructions.html.erb
+++ b/app/views/user_mailer/unlock_instructions.html.erb
@@ -4,4 +4,4 @@
 <p><%= account_name.humanize %> locks do not lock production accounts.</p>
 <% end %>
 
-<p>Your account will be unlocked at <%= unlock_time %>. If you need your account unlocked sooner, please contact a managing <%= link_to t('department.name'), t('department.url') %> editor in your organisation (or your parent organisation). They can either unlock your account themselves or use the support form to get help from the <%= link_to t('department.name'), t('department.url') %> team.</p>
+<p>Your account will be unlocked at <%= unlock_time %>. If you need your account unlocked sooner, please contact a managing <%= link_to t('department.name'), t('department.url') %> editor in your organisation (or your parent organisation). They can use the support form to get help from the <%= link_to t('department.name'), t('department.url') %> team.</p>

--- a/app/views/user_mailer/unlock_instructions.text.erb
+++ b/app/views/user_mailer/unlock_instructions.text.erb
@@ -4,4 +4,4 @@ Your <%= t('department.name') %> Signon <%= account_name %>, for <%= @resource.e
   <%= account_name.humanize %> locks do not lock production accounts.
 <% end %>
 
-Your account will be unlocked at <%= unlock_time %>. If you need your account unlocked sooner, please contact a managing <%= t('department.name') %> editor in your organisation (or your parent organisation). They can either unlock your account themselves or use the support form to get help from the <%= t('department.name') %> team.
+Your account will be unlocked at <%= unlock_time %>. If you need your account unlocked sooner, please contact a managing <%= t('department.name') %> editor in your organisation (or your parent organisation). They can use the support form to get help from the <%= t('department.name') %> team.


### PR DESCRIPTION
Email was stating that managing editors can un-suspend and unlock
accounts. Managing editors don't have this permission.

Updated to say that they can use the support form only.

Re-opening @lutgendorff’s PRs (#486 – #491) as a single commit and pull request.