### PR TITLE
Migration to remove an org created in error

### DIFF
--- a/db/migrate/20160420145549_remove_appointed_person_for_england_and_wales_organisation.rb
+++ b/db/migrate/20160420145549_remove_appointed_person_for_england_and_wales_organisation.rb
@@ -1,0 +1,13 @@
+class RemoveAppointedPersonForEnglandAndWalesOrganisation < ActiveRecord::Migration
+  def up
+    organistion = Organisation.find_by(slug: '')
+    if organistion.present?
+      raise "Unexpected users for #{organisation.title}" if organistion.users.count > 0
+      organistion.destroy
+    end
+  end
+
+  def down
+    # This org was created in error, there's no need for a down to re-instate it
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151203161459) do
+ActiveRecord::Schema.define(version: 20160420145549) do
 
   create_table "batch_invitation_application_permissions", force: :cascade do |t|
     t.integer  "batch_invitation_id",     limit: 4, null: false


### PR DESCRIPTION
This org was created in error and we are removing it.  The traffic is very low so we're not issuing a 410, just removing it (it should never have existed so a 404 is really what we want).

This is PR 5 of 5 for removing this org.

For more detail: https://trello.com/c/jbImjyLP/359-delete-an-org-page-5
