### PR TITLE
Create Signon Users Analytics

### DIFF
--- a/app/presenters/usage_presenter.rb
+++ b/app/presenters/usage_presenter.rb
@@ -1,0 +1,56 @@
+require 'csv'
+
+class UsagePresenter
+  include UsersHelper
+
+  attr_reader :start_date, :end_date
+
+  def initialize(start_date, end_date)
+    @start_date = start_date.beginning_of_day
+    @end_date = end_date.end_of_day
+  end
+
+  def write_csv(path)
+    CSV.open(File.join(path, "usage_report_#{start_date.to_date}_#{end_date.to_date}.csv"), "wb") do |csv|
+      build_csv(csv)
+    end
+  end
+
+private
+
+  def build_csv(csv)
+    csv << header_row
+    start_date_m = start_date.beginning_of_month
+
+    while start_date_m < end_date
+      end_date_m = start_date_m.end_of_month
+
+      active_users = User.where("created_at <= ? and (suspended_at is NULL or suspended_at > ?)", end_date_m, end_date_m).
+        group(:organisation_id).count
+      suspended_users = User.where("suspended_at <= ?", end_date_m).
+        group(:organisation_id).count
+      total_count = {}
+      (active_users.keys | suspended_users.keys).each do |key|
+        total_count[key] = {active: active_users[key], suspended: suspended_users[key]}
+      end
+
+      month = start_date_m.strftime("%B, %Y")
+      orgs = Organisation.all.select(:id, :name).index_by(&:id)
+
+      total_count.each do |org_id, count|
+        csv << [month, orgs[org_id].try(:name), count[:active], count[:suspended]]
+      end
+
+      start_date_m = (start_date_m + 1.month).beginning_of_month
+    end
+  end
+
+  def header_row
+    [
+      'Month',
+      'Organisation',
+      'Active Users',
+      'Suspended Users'
+    ]
+  end
+end

--- a/lib/tasks/export_usage_stats.rake
+++ b/lib/tasks/export_usage_stats.rake
@@ -1,0 +1,18 @@
+desc "Export new users between 2 dates, as CSV"
+
+task :export_usage_stats, [:start_date, :end_date] => :environment do |_, args|
+  USAGE_MESSAGE = "usage: rake export_usage_stats[<start_date>, <end_date>]\n"\
+    "dates format: YYYY-MM-DD"
+  abort USAGE_MESSAGE unless args[:start_date] && args[:end_date]
+  begin
+    start_date = Date.parse(args[:start_date])
+    end_date = Date.parse(args[:end_date])
+  rescue ArgumentError
+    abort USAGE_MESSAGE
+  end
+
+  path = "#{ENV['GOVUK_APP_ROOT'] || Rails.root}/reports"
+  UsagePresenter.new(start_date, end_date).write_csv(path)
+
+  puts "Report successfully generated inside #{path} !"
+end


### PR DESCRIPTION
Produce a Signon report broken down by:

- the number of active and suspended editors
- organisation (as we define this in Whitehall document filtering)
- month (e.g. from the start of January 2015 to end of January 2016)

This can be generated via a rake task.
The dates can be customized as inputs from command line, e.g.:

`bundle exec rake export_usage_stats[2015-01-01,2016-01-31]`