### PR TITLE
Allow a user to have no application access

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ end
 group :development, :test do
   gem 'jasmine', '2.1.0'
   gem 'govuk-lint', '~> 0.4'
+  gem 'pry-byebug'
 end
 
 gem 'logstasher', '0.4.8'
@@ -77,5 +78,4 @@ group :test do
   gem 'ci_reporter', '1.7.0'
   gem 'timecop', '0.7.1'
   gem 'shoulda-context', '1.2.1', require: false
-  gem 'pry-byebug'
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,6 +5,7 @@ class UsersController < ApplicationController
 
   before_filter :authenticate_user!, except: :show
   before_filter :load_and_authorize_user, except: [:index, :show]
+  before_filter :allow_no_application_access, only: [:update]
   helper_method :applications_and_permissions, :any_filter?
   respond_to :html
 
@@ -208,6 +209,12 @@ class UsersController < ApplicationController
     if user.send_two_step_flag_notification?
       UserMailer.two_step_flagged(user).deliver_later
     end
+  end
+
+  # When no permissions are selected for a user, we set the value to [] so
+  # a user can have no permissions
+  def allow_no_application_access
+    params[:user][:supported_permission_ids] ||= []
   end
 
   def user_params

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -599,6 +599,28 @@ class UsersControllerTest < ActionController::TestCase
 
         put :update, id: another_user.id, user: { name: "New Name" }
       end
+
+      context "update application access" do
+        setup do
+          sign_in create(:admin_user)
+          @application = create(:application)
+          @another_user = create(:user)
+        end
+
+        should "remove all applications access for a user" do
+          @another_user.grant_application_permission(@application, 'signin')
+
+          put :update, id: @another_user.id, user: {}
+
+          assert_empty @another_user.reload.application_permissions
+        end
+
+        should "add application access for a user" do
+          put :update, id: @another_user.id, user: { supported_permission_ids: [@application.id] }
+
+          assert_equal 1, @another_user.reload.application_permissions.count
+        end
+      end
     end
 
     context "PUT resend_email_change" do


### PR DESCRIPTION
It is now possible for a user to have a Signon account but not to have
access to any applications. Previously at least one application needed
to be selected.

In response to this [Zendesk ticket](https://govuk.zendesk.com/agent/tickets/1345740).