### PR TITLE
Update OrganisationFetcher to handle recreations

### DIFF
--- a/lib/organisations_fetcher.rb
+++ b/lib/organisations_fetcher.rb
@@ -25,9 +25,16 @@ private
   end
 
   def update_or_create_organisation(organisation_data)
-    organisation = Organisation.find_or_initialize_by(content_id: organisation_data.details.content_id)
+    content_id = organisation_data.details.content_id
+    slug = organisation_data.details.slug
+
+    organisation = Organisation.find_by(content_id: content_id) ||
+      Organisation.find_by(slug: slug) ||
+      Organisation.new(content_id: content_id)
+
     update_data = {
-      slug: organisation_data.details.slug,
+      content_id: content_id,
+      slug: slug,
       name: organisation_data.title,
       organisation_type: organisation_data.format,
       abbreviation: organisation_data.details.abbreviation,

--- a/test/models/organisations_fetcher_test.rb
+++ b/test/models/organisations_fetcher_test.rb
@@ -57,6 +57,29 @@ class OrganisationsFetcherTest < ActiveSupport::TestCase
     assert_equal("new-slug", Organisation.first.slug)
   end
 
+  test "it updates an existing organisation when its content id changes" do
+    content_id = 'abc-123'
+    slug = 'ministry-of-fun'
+    organisation = create(
+      :organisation,
+      name: 'Ministry Of Misery',
+      slug: slug
+    )
+    assert_equal(1, Organisation.count)
+
+    bodies = [
+      organisation_details_for_slug(slug, content_id)
+    ]
+    organisations_api_has_organisations_with_bodies(bodies)
+
+    OrganisationsFetcher.new.call
+
+    assert_equal(1, Organisation.count)
+    organisation.reload
+    assert_equal('Ministry Of Fun', organisation.name)
+    assert_equal('abc-123', organisation.content_id)
+  end
+
   test "it updates the child organisation with information about it's parent" do
     slug = 'ministry-of-fun'
     fun = create(:organisation, name: 'Ministry of Fun', slug: slug)


### PR DESCRIPTION
The API can return an organisation with a `slug` that matches one we already know about, however the `content_id` may differ from the one we hold locally. This can happen if within the API the organisation has been destroyed and then recreated with the same `slug`. In this instance the organisation is assigned a new `content_id` by the API and causes a conflict with our internal representation when we try to sync.