### PR TITLE
Improve cookies security

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,7 @@
 require File.expand_path('../boot', __FILE__)
 
 require 'rails/all'
+require_relative '../lib/same_site_security/middleware'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -56,5 +57,7 @@ module Signonotron2
     config.autoload_paths << Rails.root.join('lib')
 
     config.active_job.queue_adapter = :sidekiq
+
+    config.middleware.insert_before 0, SameSiteSecurity::Middleware
   end
 end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,4 +1,5 @@
 # Be sure to restart your server when you modify this file.
 
 Signonotron2::Application.config.session_store :cookie_store, key: '_signonotron2_session',
-                                                secure: Rails.env.production?
+                                                secure: Rails.env.production?,
+                                                httponly: true

--- a/lib/same_site_security/middleware.rb
+++ b/lib/same_site_security/middleware.rb
@@ -1,0 +1,20 @@
+module SameSiteSecurity
+  class Middleware
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      req = Rack::Request.new(env)
+      status, headers, response = @app.call(env)
+      if cookies = headers['Set-Cookie']
+        cookies = cookies.split("\n") unless cookies.is_a?(Array)
+
+        headers['Set-Cookie'] = cookies.map { |cookie|
+          cookie.to_s + "; SameSite=Lax"
+        }.join("\n")
+      end
+      [status, headers, response]
+    end
+  end
+end

--- a/spec/features/cookies_security.rb
+++ b/spec/features/cookies_security.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+feature 'cookies security' do
+  scenario 'with valid email and password' do
+    user = FactoryGirl.create(:two_step_enabled_user)
+    sign_up_with user.email, user.password
+    visit new_user_session_path
+    response_cookies = Capybara.current_session.driver.response.headers["Set-Cookie"]
+    expect(response_cookies).to include('HttpOnly')
+    expect(response_cookies).to include('SameSite=Lax')
+  end
+
+  def sign_up_with(email, password)
+    visit new_user_session_path
+    fill_in 'Email', with: email
+    fill_in 'Passphrase', with: password
+    click_button 'Sign in'
+  end
+end

--- a/spec/unit/same_site_security/middleware.rb
+++ b/spec/unit/same_site_security/middleware.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+describe SameSiteSecurity::Middleware do
+  headers = {'Content-Type' => 'text/plain', 'Set-Cookie' => '_signonotron2_session=abcd'}
+  let(:app) { Proc.new { [200, headers, ['OK']]} }
+  subject { SameSiteSecurity::Middleware.new(app) }
+
+  context "when called with a GET request" do
+    let(:request) { Rack::MockRequest.new(subject) }
+
+    it "sets cookies attributes properly" do
+      env = Rack::MockRequest.env_for("/a-protected-url")
+      status, headers = subject.call(env)
+
+      cookies = headers['Set-Cookie']
+      expect(cookies).to include('_signonotron2_session=abcd')
+      expect(cookies).to include('SameSite=Lax')
+    end
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/DlBVF1KZ/426-improve-signon-cookie-security-small

Set the HttpOnly, Secure and SameSite=lax attributes for cookies, so 2-step-verification cookies could not be stolen by a man-in-the-middle attacker.