### PR TITLE
Force users to sign in after resetting password

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -193,6 +193,10 @@ Devise.setup do |config|
   # change their passwords.
   config.reset_password_within = 6.hours
 
+  # When set to false, does not sign a user in automatically after their password is
+  # reset. Defaults to true, so a user is signed in automatically after a reset.
+  config.sign_in_after_reset_password = false
+
   # ==> Configuration for :encryptable
   # Allow you to use another encryption algorithm besides bcrypt (default). You can use
   # :sha1, :sha512 or encryptors from others authentication tools as :clearance_sha1,


### PR DESCRIPTION
Previously, users would be automatically logged in once they had reset
their password. This had the effect of allowing users to bypass 2SV by
requesting a password reset.

Forcing users to sign in after they’ve reset their password closes this
loophole.

This feature didn't exist when 2SV was originally implemented.