### PR TITLE
Add permissions migration task

### DIFF
--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -101,4 +101,16 @@ namespace :users do
       raise "Could not find an application called 'Content Preview'"
     end
   end
+
+  desc "Migrates user permissions from source to target application"
+  task migrate_permissions: :environment do
+    source_application = ENV["SOURCE"]
+    target_application = ENV["TARGET"]
+
+    unless source_application && target_application
+      raise "Please supply SOURCE and TARGET application names"
+    end
+
+    UserPermissionMigrator.migrate(source: source_application, target: target_application)
+  end
 end

--- a/lib/user_permission_migrator.rb
+++ b/lib/user_permission_migrator.rb
@@ -1,0 +1,23 @@
+class UserPermissionMigrator
+  def self.migrate(source:, target:)
+    source_app = Doorkeeper::Application.find_by!(name: source)
+    target_app = Doorkeeper::Application.find_by!(name: target)
+    source_app_supported_permissions = source_app.supported_permissions
+    target_app_supported_permissions = target_app.supported_permissions
+
+    permissions = source_app_supported_permissions.map do |permission|
+      [permission.name, target_app_supported_permissions.find_by!(name: permission.name)]
+    end
+
+    permission_mappings = permissions.to_h
+
+    User.all.each do |user|
+      if user.has_access_to?(source_app)
+        permissions = user.permissions_for(source_app)
+        permissions.each do |permission|
+          UserApplicationPermission.create user: user, application: target_app, supported_permission: permission_mappings[permission]
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/user_permission_migrator_spec.rb
+++ b/spec/unit/user_permission_migrator_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe UserPermissionMigrator do
+  let(:specialist_publisher) { FactoryGirl.create(:application, name: "Specialist Publisher") }
+  let(:manuals_publisher) { FactoryGirl.create(:application, name: "Manuals Publisher") }
+  let(:unrelated_application) { FactoryGirl.create(:application, name: "unrelated application") }
+
+  before do
+    FactoryGirl.create(:supported_permission, application: specialist_publisher, name: "gds_editor")
+    FactoryGirl.create(:supported_permission, application: specialist_publisher, name: "editor")
+
+    FactoryGirl.create(:supported_permission, application: manuals_publisher, name: "gds_editor")
+    FactoryGirl.create(:supported_permission, application: manuals_publisher, name: "editor")
+
+    FactoryGirl.create(:supported_permission, application: unrelated_application, name: "gds_editor")
+    FactoryGirl.create(:supported_permission, application: unrelated_application, name: "editor")
+  end
+
+  let!(:gds_editor) { FactoryGirl.create(:user, with_permissions: {"Specialist Publisher" => %w(editor gds_editor signin)}) }
+  let!(:editor) { FactoryGirl.create(:user, with_permissions: {"Specialist Publisher" => %w(editor signin)}) }
+  let!(:writer) { FactoryGirl.create(:user, with_permissions: {"Specialist Publisher" => %w(signin)}) }
+  let!(:user_without_access) { FactoryGirl.create(:user) }
+  let!(:user_with_unrelated_access) { FactoryGirl.create(:user, with_permissions: {"unrelated application" => %w(editor gds_editor signin)}) }
+
+  it "copies permissions over for all users of an application to another application" do
+    UserPermissionMigrator.migrate(
+      source: "Specialist Publisher",
+      target: "Manuals Publisher",
+    )
+
+    expect(gds_editor.permissions_for(manuals_publisher)).to eq %w(editor gds_editor signin)
+    expect(editor.permissions_for(manuals_publisher)).to eq %w(editor signin)
+    expect(writer.permissions_for(manuals_publisher)).to eq %w(signin)
+    expect(user_without_access.permissions_for(manuals_publisher)).to eq []
+    expect(user_with_unrelated_access.permissions_for(manuals_publisher)).to eq []
+
+    expect(gds_editor.permissions_for(specialist_publisher)).to eq %w(editor gds_editor signin)
+    expect(editor.permissions_for(specialist_publisher)).to eq %w(editor signin)
+    expect(writer.permissions_for(specialist_publisher)).to eq %w(signin)
+    expect(user_without_access.permissions_for(specialist_publisher)).to eq []
+    expect(user_with_unrelated_access.permissions_for(specialist_publisher)).to eq []
+  end
+end


### PR DESCRIPTION
https://trello.com/c/gDbYr06M/272-amend-signon-for-separation-of-finders-and-manuals-large

Adds a task to migrate permissions for users between a source and target application.
We need to do this to copy Specialist Publisher user permissions into Manuals Publisher but it should work for any pairs of applications with the same permission names.