### PR TITLE
Only link to an app's `home_uri` if it exists

### DIFF
--- a/app/views/doorkeeper_applications/index.html.erb
+++ b/app/views/doorkeeper_applications/index.html.erb
@@ -20,7 +20,7 @@
           <%= application.description %>
         </td>
         <td><%= application.redirect_uri %></td>
-        <td><%= link_to application.home_uri, application.home_uri %></td>
+        <td><%= link_to_if application.home_uri, application.home_uri, application.home_uri %></td>
         <td><%= link_to "Edit", edit_doorkeeper_application_path(application) %></td>
       </tr>
     <% end %>


### PR DESCRIPTION
`home_uri` is an optional field so don't link to it if it doesn't exist.

Fixes #247.