### PR TITLE
Record role changes in the event log

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -58,6 +58,10 @@ class UsersController < ApplicationController
         end
       end
 
+      if role_change = @user.previous_changes[:role]
+        EventLog.record_role_change(@user, role_change.first, role_change.last, current_user)
+      end
+
       redirect_to users_path, notice: "Updated user #{@user.email} successfully"
     else
       render :edit

--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -36,6 +36,7 @@ class EventLog < ActiveRecord::Base
     ACCESS_TOKEN_REVOKED                      = LogEntry.new(id: 30, description: "Access token revoked", require_application: true, require_initiator: true),
     PASSPHRASE_RESET_LOADED_BUT_TOKEN_EXPIRED = LogEntry.new(id: 31, description: "Passphrase reset page loaded but the token has expired"),
     SUCCESSFUL_PASSPHRASE_RESET               = LogEntry.new(id: 32, description: "Passphrase reset successfully"),
+    ROLE_CHANGED                              = LogEntry.new(id: 33, description: "Role changed", require_initiator: true),
   ]
 
   EVENTS_REQUIRING_INITIATOR   = EVENTS.select(&:require_initiator?)
@@ -72,6 +73,10 @@ class EventLog < ActiveRecord::Base
   def self.record_email_change(user, email_was, email_is, initiator = user)
     event = (user == initiator) ? EMAIL_CHANGE_INITIATED : EMAIL_CHANGED
     record_event(user, event, initiator: initiator, trailing_message: "from #{email_was} to #{email_is}")
+  end
+
+  def self.record_role_change(user, previous_role, new_role, initiator)
+    record_event(user, ROLE_CHANGED, initiator: initiator, trailing_message: "from #{previous_role} to #{new_role}")
   end
 
   def self.for(user)

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -593,6 +593,16 @@ class UsersControllerTest < ActionController::TestCase
         end
       end
 
+      context "changing a role" do
+        should "log an event" do
+          @user.update_column(:role, "superadmin")
+          another_user = create(:user, role: "admin")
+          put :update, id: another_user.id, user: { role: "normal" }
+
+          assert_equal 1, EventLog.where(event_id: EventLog::ROLE_CHANGED.id, uid: another_user.uid, initiator_id: @user.id).count
+        end
+      end
+
       should "push changes out to apps" do
         another_user = create(:user, name: "Old Name")
         PermissionUpdater.expects(:perform_on).with(another_user).once

--- a/test/models/event_log_test.rb
+++ b/test/models/event_log_test.rb
@@ -66,6 +66,14 @@ class EventLogTest < ActiveSupport::TestCase
     end
   end
 
+  test "records role changes with the details of the roles" do
+    user = create(:user, email: 'new@example.com')
+    admin = create(:admin_user)
+    event_log = EventLog.record_role_change(user, 'admin', 'superadmin', admin)
+
+    assert_equal 'from admin to superadmin', event_log.trailing_message
+  end
+
   test "records the initiator of the event passed as an option" do
     initiator = create(:admin_user)
     EventLog.record_event(create(:user), EventLog::EMAIL_CHANGED, initiator: initiator)


### PR DESCRIPTION
This adds event log entries like:

> Role changed by Alex Muller from admin to superadmin

Which is helpful when looking at compromised accounts.

Fixes #299.