### PR TITLE
(Soft) delete Share Sale Publisher

### DIFF
--- a/db/migrate/20170110171851_remove_share_sale_publisher.rb
+++ b/db/migrate/20170110171851_remove_share_sale_publisher.rb
@@ -1,6 +1,6 @@
 class RemoveShareSalePublisher < ActiveRecord::Migration
   def change
     share_sale_publisher = Doorkeeper::Application.find_by(name: "Share Sale Publisher")
-    share_sale_publisher.destroy if share_sale_publisher
+    share_sale_publisher.delete if share_sale_publisher
   end
 end


### PR DESCRIPTION
Amend this migration to call `delete` and not `destroy` as this [doesn't work as expected despite the examples given in the documentation](https://github.com/ActsAsParanoid/acts_as_paranoid#real-deletion). The migration has only run on integration hence the amendment.